### PR TITLE
[vite]: Rollup failed to resolve import "utils" from "/home/runner/wo…

### DIFF
--- a/packages/vis-core/src/hooks/useFeatureSelect.js
+++ b/packages/vis-core/src/hooks/useFeatureSelect.js
@@ -1,8 +1,8 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useMapContext } from "hooks";
+import { useMapContext } from "./useMapContext";
 import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
 import * as turf from "@turf/turf";
-import { getSourceLayer } from "utils";
+import { getSourceLayer } from "../utils/map";
 
 /**
  * Custom hook that enables feature selection on the map based on the current selection mode.


### PR DESCRIPTION
…rk/vis-core/vis-core/packages/vis-core/src/reducers/mapReducer.js".

Fix: Replaced alias imports like hooks and utils with relative paths so the library build can resolve them so hook file imported from the hooks re-exports the same hook creating a circular dependency so changed to import the other hook file directly


