### PR TITLE
Error fix: by adding the relative path for the updateUrlParameters

### DIFF
--- a/packages/vis-core/src/reducers/mapReducer.js
+++ b/packages/vis-core/src/reducers/mapReducer.js
@@ -1,4 +1,4 @@
-import { updateUrlParameters } from "utils";
+import { updateUrlParameters } from "../utils/api";
 
 // This function finds the first colourValue present in the state.filters in order to deduce the
 // starting map colour.


### PR DESCRIPTION
Error fix: [vite]: Rollup failed to resolve import "utils" from "/home/runner/work/vis-core/vis-core/packages/vis-core/src/reducers/mapReducer.js".


