### PR TITLE
Import fixes added

### DIFF
--- a/packages/vis-core/tsconfig.json
+++ b/packages/vis-core/tsconfig.json
@@ -17,7 +17,18 @@
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": "src",
+    "paths": {
+      "Components/*": ["Components/*"],
+      "contexts/*":   ["contexts/*"],
+      "hooks/*":      ["hooks/*"],
+      "services/*":   ["services/*"],
+      "hocs/*":       ["hocs/*"],
+      "layouts/*":    ["layouts/*"],
+      "reducers/*":   ["reducers/*"],
+      "utils/*":      ["utils/*"]
+    }
   },
   "include": ["src/**/*", "src/global.d.ts"],
   "exclude": ["dist", "node_modules"]

--- a/packages/vis-core/vite.config.ts
+++ b/packages/vis-core/vite.config.ts
@@ -35,13 +35,24 @@ export default defineConfig({
       external: ["react", "react-dom", "react/jsx-runtime", 'react-router-dom', '@mapbox/mapbox-gl-draw', 
         'mapbox-gl', '@turf/turf', 'chroma-js', "polished", "js-cookie", "@auth0/auth0-react", "lodash.debounce",
         "@heroicons/react", "leaflet", "lz-string", "jwt-decode", "html-react-parser", "dompurify", "colorbrewer",
-        "@ookla/mapbox-gl-draw-rectangle", "@mapcomponents/react-maplibre",
-        "dotenv", "g",
+        "@ookla/mapbox-gl-draw-rectangle", "@mapcomponents/react-maplibre"
       ],
       output: {
         globals: { react: "React", "react-dom": "ReactDOM" }
       }
     },
     sourcemap: true
-  }
+  },
+  resolve: {
+    alias: {
+      Components: path.resolve(__dirname, "src/Components"),
+      contexts:   path.resolve(__dirname, "src/contexts"),
+      hooks:      path.resolve(__dirname, "src/hooks"),
+      services:   path.resolve(__dirname, "src/services"),
+      hocs:       path.resolve(__dirname, "src/hocs"),
+      layouts:    path.resolve(__dirname, "src/layouts"),
+      reducers:   path.resolve(__dirname, "src/reducers"),
+      utils:      path.resolve(__dirname, "src/utils"),
+    },
+  },
 });


### PR DESCRIPTION
Added resolve.alias in Vite and baseUrl/paths in tsconfig for Components/, contexts/, hooks/, services/, hocs/, layouts/, reducers/, utils/. Fixes Rollup “failed to resolve import” without touching module code.