### PR TITLE
Declared styled-components as a peer dependency

### DIFF
--- a/packages/vis-core/package.json
+++ b/packages/vis-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transport-for-the-north/vis-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",
@@ -74,7 +74,8 @@
     "mapbox-gl": "^x",
     "polished": "^4.3.1",
     "react": "^18 || ^19",
-    "react-dom": "^18 || ^19"
+    "react-dom": "^18 || ^19",
+    "styled-components": "^6.1.19"
   },
   "devDependencies": {
     "@auth0/auth0-react": "^2.6.0",

--- a/packages/vis-core/src/Components/HomePage/HomePage.jsx
+++ b/packages/vis-core/src/Components/HomePage/HomePage.jsx
@@ -128,7 +128,7 @@ export const HomePage = () => {
         {appContext.introduction && (
           <section className="introduction container-content">
             <h2>About</h2>
-            <p className="container-intro">{parse(appContext.introduction)}</p>
+            <div className="container-intro">{parse(appContext.introduction)}</div>
           </section>
         )}
 

--- a/packages/vis-core/vite.config.ts
+++ b/packages/vis-core/vite.config.ts
@@ -32,10 +32,10 @@ export default defineConfig({
         `${entryName}.${format === 'es' ? 'js' : 'cjs'}`,
     },
     rollupOptions: {
-      external: ["react", "react-dom", "react/jsx-runtime", 'react-router-dom', '@mapbox/mapbox-gl-draw', 
-        'mapbox-gl', '@turf/turf', 'chroma-js', "polished", "js-cookie", "@auth0/auth0-react", "lodash.debounce",
+      external: ["react", "react-dom", "react/jsx-runtime", "react-router-dom", "@mapbox/mapbox-gl-draw", 
+        "mapbox-gl", "@turf/turf", "chroma-js", "polished", "js-cookie", "@auth0/auth0-react", "lodash.debounce",
         "@heroicons/react", "leaflet", "lz-string", "jwt-decode", "html-react-parser", "dompurify", "colorbrewer",
-        "@ookla/mapbox-gl-draw-rectangle", "@mapcomponents/react-maplibre"
+        "@ookla/mapbox-gl-draw-rectangle", "@mapcomponents/react-maplibre", "styled-components"
       ],
       output: {
         globals: { react: "React", "react-dom": "ReactDOM" }


### PR DESCRIPTION
It was bundling styled-components inside vis-core.

That creates a second ThemeContext, so the app’s <ThemeProvider> can’t reach vis-core and theme.mq.mobile is undefined.

So moved the styled components to the peerDep.

Another fix: replaced <p> tag to <div> as Vite throwing error that <p> cannot be a descendant of <p>.