### PR TITLE
runtime map API token support

### DIFF
--- a/packages/vis-core/package.json
+++ b/packages/vis-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transport-for-the-north/vis-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/vis-core/src/contexts/MapContext.jsx
+++ b/packages/vis-core/src/contexts/MapContext.jsx
@@ -47,7 +47,7 @@ export const MapProvider = ({ children }) => {
 
   // Initialize state within the provider function
   const initialState = {
-    mapStyle: appContext.mapStyle || defaultMapStyle,
+    mapStyle: appContext.mapStyle || defaultMapStyle(),
     mapCentre: pageContext.customMapCentre
       ? parseStringToArray(pageContext.customMapCentre)
       : defaultMapCentre,

--- a/packages/vis-core/src/defaults.js
+++ b/packages/vis-core/src/defaults.js
@@ -1,14 +1,22 @@
-export const mapStyles = {
-  geoapifyPositron: `https://maps.geoapify.com/v1/styles/positron/style.json?apiKey=${import.meta.env.VITE_APP_MAP_API_TOKEN}`,
+let mapApiToken = '';
 
-  osMapsApiRaster: {
+export const setMapApiToken = (token) => {
+  mapApiToken = token;
+};
+
+export const getMapApiToken = () => mapApiToken;
+
+export const mapStyles = {
+  geoapifyPositron: () => `https://maps.geoapify.com/v1/styles/positron/style.json?apiKey=${mapApiToken}`,
+
+  osMapsApiRaster: () => ({
     version: 8,
     glyphs: "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
     sources: {
       "raster-tiles": {
         type: "raster",
         tiles: [
-          `https://api.os.uk/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png?key=${import.meta.env.VITE_APP_MAP_API_TOKEN}`,
+          `https://api.os.uk/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png?key=${mapApiToken}`,
         ],
         tileSize: 256,
       },
@@ -20,13 +28,15 @@ export const mapStyles = {
         source: "raster-tiles",
       },
     ],
-  },
+  }),
 
   osVectorTileApiOpenGreyscale:
     "https://raw.githubusercontent.com/Transport-for-the-North/OS-Vector-Tile-API-Stylesheets/refs/heads/main/OS_VTS_3857_Open_Light.json",
 };
 
-export const defaultMapStyle = mapStyles.geoapifyPositron;
+export const getDefaultMapStyle = () => mapStyles.geoapifyPositron();
+// Replace the direct export with a function
+export const defaultMapStyle = getDefaultMapStyle;
 export const defaultMapCentre = [-2.2, 54.2];
 export const defaultMapZoom = 7.5;
 

--- a/packages/vis-core/src/hooks/useDualMaps.jsx
+++ b/packages/vis-core/src/hooks/useDualMaps.jsx
@@ -33,7 +33,7 @@ export const useDualMaps = (
      */
     const initializeDualMap = () => {
       const commonOptions = {
-        style: mapStyle || defaultMapStyle,
+        style: mapStyle || defaultMapStyle(),
         center: mapCentre || defaultMapCentre,
         zoom: mapZoom != null ? mapZoom : defaultMapZoom,
         // maxZoom: 16,
@@ -48,7 +48,7 @@ export const useDualMaps = (
         transformRequest: (url, resourceType) => {
           if (resourceType !== 'Style' && url.startsWith('https://api.os.uk') ) {
             url = new URL(url);
-            if (!url.searchParams.has('key')) url.searchParams.append('key', import.meta.env.VITE_APP_MAP_API_TOKEN);
+            if (!url.searchParams.has('key')) url.searchParams.append('key', getMapApiToken());
             if (!url.searchParams.has('srs')) url.searchParams.append('srs', 3857);
             return {
               url: new Request(url).url

--- a/packages/vis-core/src/hooks/useMap.jsx
+++ b/packages/vis-core/src/hooks/useMap.jsx
@@ -54,7 +54,7 @@ export const useMap = (mapContainerRef, mapStyle, mapCentre, mapZoom, extraCopyr
 
       const mapInstance = new maplibregl.Map({
         container,
-        style: mapStyle || defaultMapStyle,
+        style: mapStyle || defaultMapStyle(),
         center: mapCentre || defaultMapCentre,
         zoom: mapZoom != null ? mapZoom : defaultMapZoom,
         // maxZoom: 15,
@@ -69,7 +69,7 @@ export const useMap = (mapContainerRef, mapStyle, mapCentre, mapZoom, extraCopyr
         transformRequest: (url, resourceType) => {
           if( resourceType !== 'Style' && url.startsWith('https://api.os.uk') ) {
               url = new URL(url);
-              if(! url.searchParams.has('key') ) url.searchParams.append('key', import.meta.env.VITE_APP_MAP_API_TOKEN);
+              if(! url.searchParams.has('key') ) url.searchParams.append('key', getMapApiToken());
               if(! url.searchParams.has('srs') ) url.searchParams.append('srs', 3857);
               return {
                   url: new Request(url).url

--- a/packages/vis-core/src/index.tsx
+++ b/packages/vis-core/src/index.tsx
@@ -8,6 +8,8 @@ export * as reducers from './reducers';
 export * as services from './services';
 export * as utils from './utils';
 
+export { setMapApiToken } from './defaults';
+
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 
 


### PR DESCRIPTION
- added setMapApiToken/getMapApiToken to manage map API token at runtime
- converted mapStyles to functions so they read the current token when called
- made defaultMapStyle a getter function (getDefaultMapStyle) and export it
- use getMapApiToken in transformRequest hooks (useMap, useDualMaps) instead of import.meta.env
- re-export setMapApiToken from package index for consumers
