### PR TITLE
Styles fix

### DIFF
--- a/packages/vis-core/package.json
+++ b/packages/vis-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transport-for-the-north/vis-core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
Added side effects true for .css files which tells the bundler to keep any file ending in .css