### PR TITLE
Final api fix

### DIFF
--- a/packages/vis-core/package.json
+++ b/packages/vis-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transport-for-the-north/vis-core",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",
@@ -20,6 +20,16 @@
       "require": "./dist/index.cjs"
     },
     "./style.css": "./dist/style.css",
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "import": "./dist/runtime.js",
+      "require": "./dist/runtime.cjs"
+    },
+    "./defaults": {
+      "types": "./dist/defaults.d.ts",
+      "import": "./dist/defaults.js",
+      "require": "./dist/defaults.cjs"
+    },
     "./Components": {
       "types": "./dist/Components.d.ts",
       "import": "./dist/Components.js",

--- a/packages/vis-core/src/index.tsx
+++ b/packages/vis-core/src/index.tsx
@@ -1,4 +1,8 @@
 // packages/vis-core/src/index.ts
+export * from './defaults';
+export {
+  setMapApiToken, getMapApiToken, setProdOrDev, getProdOrDev, setApiBaseDomain, getApiBaseDomain, setApiBaseDomainDev, getApiBaseDomainDev,
+} from './runtime';
 export * as Components from './Components';
 export * as contexts from './contexts';
 export * as hocs from './hocs';
@@ -7,10 +11,6 @@ export * as layouts from './layouts';
 export * as reducers from './reducers';
 export * as services from './services';
 export * as utils from './utils';
-
-export {
-  setMapApiToken, getMapApiToken, setProdOrDev, getProdOrDev, setApiBaseDomain, getApiBaseDomain, setApiBaseDomainDev, getApiBaseDomainDev,
-} from './runtime';
 
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 


### PR DESCRIPTION
given consumers a deep path to the runtime and defaults in package.js on, so the app can’t import the runtime without also loading the whole root


