### PR TITLE
Base api changes

### DIFF
--- a/packages/vis-core/package.json
+++ b/packages/vis-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transport-for-the-north/vis-core",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/vis-core/src/defaults.js
+++ b/packages/vis-core/src/defaults.js
@@ -1,6 +1,6 @@
 import { getMapApiToken } from './runtime'; 
 export const mapStyles = {
-  geoapifyPositron: () => `https://maps.geoapify.com/v1/styles/positron/style.json?apiKey=${getMapApiToken}`,
+  geoapifyPositron: () => `https://maps.geoapify.com/v1/styles/positron/style.json?apiKey=${getMapApiToken()}`,
 
   osMapsApiRaster: () => ({
     version: 8,
@@ -9,7 +9,7 @@ export const mapStyles = {
       "raster-tiles": {
         type: "raster",
         tiles: [
-          `https://api.os.uk/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png?key=${getMapApiToken}`,
+          `https://api.os.uk/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png?key=${getMapApiToken()}`,
         ],
         tileSize: 256,
       },


### PR DESCRIPTION
When app start it imports vis-core modules which create the base service instances. only after that app called the setters so that is why those values left empty like this. So even though the app later set the values, the already created services were showing blank values. So made baseService lazy about reading config by read current values each time we build a URL

Base service reads the domain in the constructor and stored it which is the issue for not reading the values, now changed that the logic is moved to read the domain every time inside _buildUrl()


