### PR TITLE
Maplayout looping error fix

### DIFF
--- a/packages/vis-core/package.json
+++ b/packages/vis-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transport-for-the-north/vis-core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
@@ -205,10 +205,12 @@ export const MapLayout = () => {
 
     const validatedFilters = updateFilterValidity(state, filterState);
 
-    dispatch({
-      type: "UPDATE_FILTER_VALUES",
-      payload: { updatedFilters: validatedFilters },
-    });
+    if (JSON.stringify(validatedFilters) !== JSON.stringify(state.filters)) {
+      dispatch({
+        type: "UPDATE_FILTER_VALUES",
+        payload: { updatedFilters: validatedFilters },
+      });
+    }
 
     state.filters.forEach((filter) => {
       let selectedValue


### PR DESCRIPTION
Bug: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.

Error Fix: Fixed infinite render loop by guarding UPDATE_FILTER_VALUES dispatch. Added an if condition so only dispatches if the filters are actually different from what’s already in state.