### PR TITLE
Add client-side filtering for records endpoint

### DIFF
--- a/packages/vis-core/src/Components/DirectoryScorecardsPage/DirectoryScorecardsPage.jsx
+++ b/packages/vis-core/src/Components/DirectoryScorecardsPage/DirectoryScorecardsPage.jsx
@@ -6,6 +6,7 @@ import { Scorecard } from "Components/Scorecard";
 import { TopFilters } from "./TopFilters";
 import { api } from "services";
 import { applyTopFilterScoping } from "utils/applyTopFilterScoping";
+import { applyWhereConditions } from "utils/config";
 
 import {
   DetailsGrid,
@@ -58,9 +59,16 @@ export function DirectoryScorecardsPage() {
     };
   }, [config.recordsEndpoint, filters, filterState]);
 
+  // Scope the records based on any client-side filter conditions, post-server fetch
+  const clientScopedRecords = useMemo(() => {
+    const where = config.recordsEndpoint?.clientFilter?.where;
+    if (!Array.isArray(where) || where.length === 0) return records;
+    return applyWhereConditions(records, where);
+  }, [records, config.recordsEndpoint]);
+
   const scopedRows = useMemo(
-    () => applyTopFilterScoping(records, filters, filterState, isReady),
-    [records, filters, filterState, isReady]
+    () => applyTopFilterScoping(clientScopedRecords, filters, filterState, isReady),
+    [clientScopedRecords, filters, filterState, isReady]
   );
 
   const idAccessor = config.selection?.rowIdAccessor || "id";


### PR DESCRIPTION
Implement client-side filtering for the records endpoint on the DirectoryScorecardsPage, allowing dynamic filtering of displayed records without needing to configure additional server requests.

**This one unlocks the full capability of the latest version of Economic Summaries in Strat Analysis -- specifically, the ability to filter by programme ID within the client.**

# Changes

*Added client-side filtering logic to the records endpoint, using existing metadata tables filtering mechanisms. No changes to tests or dependencies were made.*