### PR TITLE
Enable backwards compatibility with error provider

### DIFF
--- a/packages/vis-core/src/contexts/MapContext.jsx
+++ b/packages/vis-core/src/contexts/MapContext.jsx
@@ -48,7 +48,9 @@ export const MapProvider = ({ children }) => {
   const appContext = useContext(AppContext);
   const pageContext = useContext(PageContext);
   const { dispatch: filterDispatch } = useContext(FilterContext);
-  const { state: errorState, dispatch: errorDispatch } = useContext(ErrorContext);
+  const errorContext = useContext(ErrorContext);
+  const errorDispatch = errorContext?.dispatch ?? (() => {}); // no-op if provider missing
+  const errorState = errorContext?.state ?? null;
 
   // Initialize state within the provider function
   const initialState = {

--- a/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
+++ b/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
@@ -184,8 +184,11 @@ export const useFetchVisualisationData = (
   // Track previous combined params (query + path) to avoid refetching unnecessarily.
   const prevParamsRef = useRef();
   const prevVisualisationNameRef = useRef();
+  
   // Access ErrorContext to display an overlay for missing parameters (if provider present)
-  const { state: errorState, dispatch: errorDispatch } = useContext(ErrorContext);
+  const errorContext = useContext(ErrorContext);
+  const errorDispatch = errorContext?.dispatch ?? (() => {}); // no-op if provider missing
+  const errorState = errorContext?.state ?? null;
 
   /**
    * - React StrictMode (dev) mounts/unmounts quickly; a 400ms debounced call can be cancelled


### PR DESCRIPTION
Spotted an issue with error provider when not using BaseApp. Provider not implemented so wherever it's used, it gives an error unless we no-op. 

Have refactored the usage of ErrorContext to ensure backwards compatibility. The code now safely handles the absence of the ErrorProvider by providing default values for state and dispatch.