### PR TITLE
Remove old BandEditor from LayerControlEntry component

### DIFF
--- a/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.jsx
@@ -472,7 +472,7 @@ export const LayerControlEntry = memo(
                   layerName={layer.id}
                 />}
 
-              {/* BandEditor for continuous/diverging only */}
+              {/* BandEditor for continuous/diverging only
               {(colorStyle === "continuous" || colorStyle === "diverging") && hasDefaultBands && (
                 <BandEditor
                   bands={hasDefaultBands.values}
@@ -482,7 +482,7 @@ export const LayerControlEntry = memo(
                   }}
                   isDiverging={colorStyle === "diverging"}
                 />
-              )}
+              )} */}
 
               {!enforceNoClassificationMethod && <ClassificationDropdown
                 classType={{


### PR DESCRIPTION
Remove the first-draft BandEditor from the LayerControlEntry component. This change prepares for future updates/corrections in PR #64.