### PR TITLE
feat(spiderfier): add spiderfier functionality for coincident points

### DIFF
--- a/packages/vis-core/src/Components/MapLayout/Map.jsx
+++ b/packages/vis-core/src/Components/MapLayout/Map.jsx
@@ -1,5 +1,5 @@
 import "maplibre-gl/dist/maplibre-gl.css";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import styled from "styled-components";
 
 import { DynamicLegend } from "Components";
@@ -9,6 +9,7 @@ import { api } from "services";
 import maplibregl from "maplibre-gl";
 import { VisualisationManager } from "./VisualisationManager";
 import { Layer } from "./Layer";
+import { SpiderLayer } from "./SpiderLayer";
 import {
   getSourceLayer,
   getFeatureStateValue,
@@ -35,6 +36,41 @@ const StyledMapContainer = styled.div`
    height: auto;             /* let content dictate height */
   }
 `;
+
+/**
+ * When we add spider layers to the map, these are hoverable as they are 
+ * children/siblings of other layers.
+ * 
+ * This function returns spider layer ids for all point layers present on the map,
+ * to include in hover/click queries.
+ */
+function allSpiderOverlayLayerIds(map, stateLayers) {
+  const ids = [];
+  Object.keys(stateLayers).forEach((layerId) => {
+    const pointsId = `${layerId}-spider`;
+    const linksId = `${layerId}-spider-links`;
+    if (map.getLayer(pointsId)) ids.push(pointsId);
+    if (map.getLayer(linksId)) ids.push(linksId);
+  });
+  return ids;
+}
+
+/**
+ * Resolve the base layer of a spider layer.
+ * 
+ * Spider layers are automatically generated when spiderfyOverlappingPoints
+ * is true, and the layer is a point/circle layer.
+ * 
+ * This function is primarily useful for cascading custom hover functionality
+ * through to spider layers.
+ *
+ * @returns {string} The name of the parent layer for a spider layer.
+ */
+function resolveBaseLayerIdFromSpiderLayerId(layerId) {
+  if (layerId.endsWith("-spider")) return layerId.slice(0, -"-spider".length);
+  if (layerId.endsWith("-spider-links")) return layerId.slice(0, -"-spider-links".length);
+  return layerId;
+}
 
 /**
  * Map component that renders a map using MapLibre GL and handles layers,
@@ -299,9 +335,10 @@ const Map = (props) => {
           return;
         }
         
+        const spiderOverlayLayerIds = allSpiderOverlayLayerIds(map, state.layers); // Added so we can account for spider layers (dupe points)
         const featuresWithDuplicates = map.queryRenderedFeatures(bufferedPoint, {
-          layers: hoverableLayers,
-        });
+           layers: [...hoverableLayers, ...spiderOverlayLayerIds],
+         });
         
         // Filter out any features that don't have required properties
         const validFeatures = (featuresWithDuplicates || []).filter(
@@ -337,10 +374,10 @@ const Map = (props) => {
       }
 
       // Filter features based on their individual layer's shouldHaveHoverOnlyOnData setting
+      // NB if it's a spider layer, we resolve to the base layer to get custom hover handling.
       const filteredFeatures = features.filter((feature) => {
-        const layerId = feature.layer?.id;
-        if (!layerId) return false;
-        
+        const rawLayerId = feature.layer.id;
+        const layerId = resolveBaseLayerIdFromSpiderLayerId(rawLayerId);
         const layerConfig = state.layers[layerId];
         if (!layerConfig) return false;
         
@@ -470,20 +507,18 @@ const Map = (props) => {
 
       let descriptions = [];
       // Track API requests and how they map back to description indexes so we can merge results precisely
-      const apiRequests = [];
+      // NB if it's a spider layer, we resolve to the base layer to get custom tooltip metadata.
+  const apiRequests = [];
       const requestIndexByDescriptionIndex = {};
 
       filteredFeatures.forEach((feature) => {
-        const layerId = feature.layer.id;
+        const rawLayerId = feature.layer.id;
+        const layerId = resolveBaseLayerIdFromSpiderLayerId(rawLayerId);
         const layerConfig = state.layers[layerId];
-        
-        // Skip if no layer config found
-        if (!layerConfig) return;
-        
-        const customTooltip = layerConfig.customTooltip;
-        const hoverNulls = layerConfig.hoverNulls ?? true;
-        const shouldIncludeMetadata = layerConfig.hoverTipShouldIncludeMetadata;
-        const shouldHaveHoverOnlyOnData = layerConfig.shouldHaveHoverOnlyOnData ?? false;
+        const customTooltip = layerConfig?.customTooltip;
+        const hoverNulls = layerConfig?.hoverNulls ?? true;
+        const shouldIncludeMetadata = layerConfig?.hoverTipShouldIncludeMetadata;
+        const shouldHaveHoverOnlyOnData = layerConfig?.shouldHaveHoverOnlyOnData ?? false;
 
         // Safely get feature value
         const featureValue = getFeatureStateValue(feature);
@@ -1375,7 +1410,13 @@ const Map = (props) => {
   return (
     <StyledMapContainer ref={mapContainerRef}>
       {Object.values(state.layers).map((layer) => (
+      <>
         <Layer key={layer.name} layer={layer} />
+        { /* Create a sibling 'spider' layer for all point layers, to deal with overlaps */}
+        {layer.type === 'tile' && layer.geometryType === 'point' && Boolean(layer.spiderfyOverlappingPoints) && (
+          <SpiderLayer key={`${layer.name}_spider`} baseLayerId={layer.name} />
+        )}
+      </>
       ))}
       {state.visualisations && <VisualisationManager
         visualisationConfigs={state.visualisations}

--- a/packages/vis-core/src/Components/MapLayout/SpiderLayer.jsx
+++ b/packages/vis-core/src/Components/MapLayout/SpiderLayer.jsx
@@ -1,0 +1,246 @@
+import { useEffect, useRef } from "react";
+import { useMapContext } from "hooks";
+import { getSourceLayer } from 'utils';
+import {
+  ensureSpiderHoverSelectLayers,
+  buildSpiderDataOffsetOne,
+  collectSourcePoints,
+} from "utils/mapSpiders";
+
+/**
+ * Applies or updates a filter on the parent layer to hide spiderfied duplicates.
+ * It preserves any existing filter by wrapping with an "all" clause.
+ *
+ * @param {maplibregl.Map} map
+ * @param {string} baseLayerId
+ * @param {(number|string)[]} excludeIds
+ */
+function setDuplicateExclusionFilter(map, baseLayerId, excludeIds) {
+  if (!map.getLayer(baseLayerId)) return;
+  const current = map.getFilter(baseLayerId) || true;
+  const notIn = ["!", ["in", ["get", "id"], ["literal", excludeIds]]];
+  const next = current === true ? notIn : ["all", current, notIn];
+  try {
+    map.setFilter(baseLayerId, next);
+  } catch {}
+}
+
+/**
+ * Mirrors parent paint + visibility onto the spider point layer by sampling
+ * the live map style (so runtime UI changes are preserved).
+ *
+ * @param {maplibregl.Map} map
+ * @param {string} baseLayerId
+ */
+function mirrorToOverlay(map, baseLayerId) {
+  const pointLayerId = `${baseLayerId}-spider`;
+  if (!map.getLayer(pointLayerId) || !map.getLayer(baseLayerId)) return;
+
+  const keys = [
+    "circle-color",
+    "circle-opacity",
+    "circle-radius",
+    "circle-stroke-color",
+    "circle-stroke-width",
+    "circle-stroke-opacity",
+  ];
+  const vis = map.getLayoutProperty(baseLayerId, "visibility") || "visible";
+  try {
+    map.setLayoutProperty(pointLayerId, "visibility", vis);
+  } catch {}
+
+  keys.forEach((k) => {
+    try {
+      const v = map.getPaintProperty(baseLayerId, k);
+      if (v !== undefined) map.setPaintProperty(pointLayerId, k, v);
+    } catch {}
+  });
+
+  // For links, match visibility and basic opacity
+  const linkLayerId = `${baseLayerId}-spider-links`;
+  if (map.getLayer(linkLayerId)) {
+    try {
+      map.setLayoutProperty(linkLayerId, "visibility", vis);
+    } catch {}
+    const co = map.getPaintProperty(baseLayerId, "circle-opacity");
+    const fallback = Array.isArray(co) ? co[co.length - 1] : co;
+    if (fallback != null) {
+      try {
+        map.setPaintProperty(linkLayerId, "line-opacity", fallback);
+      } catch {}
+    }
+  }
+}
+
+/**
+ * SpiderLayer: builds "offsetOne" spider overlay and hides duplicates on the parent.
+ *
+ * - Offsets all but one per coincident group (anchor remains on the parent).
+ * - Parent layer duplicates are hidden via a filter that excludes their ids.
+ * - Adds hover/select layers for spider overlays (point+line) using generic helpers [6][7].
+ * - Mirrors parent paint/visibility to the overlay from the live map style.
+ */
+export function SpiderLayer({ baseLayerId }) {
+  const { state } = useMapContext();
+  const { map } = state;
+  const debounce = useRef(null);
+  const baseFilterRef = useRef(null); // to restore on unmount
+  const prevExcludeIds = useRef([]); 
+
+  useEffect(() => {
+    if (!map) return;
+    const base = map.getLayer(baseLayerId);
+    if (!base || base.type !== "circle") return;
+
+    // Save original filter once so we can restore on unmount
+    if (baseFilterRef.current == null) {
+      try {
+        baseFilterRef.current = map.getFilter(baseLayerId) || null;
+      } catch {
+        baseFilterRef.current = null;
+      }
+    }
+
+    const pointSourceId = `${baseLayerId}-spider-src`;
+    const pointLayerId = `${baseLayerId}-spider`;
+    const linkSourceId = `${baseLayerId}-spider-links-src`;
+    const linkLayerId = `${baseLayerId}-spider-links`;
+
+    const onSourceData = (e) => {
+      // Check if the event is for our layer and if loading is complete
+      if (e.sourceId === baseLayerId && e.isSourceLoaded) {
+        schedule();
+      }
+    };
+    map.on("sourcedata", onSourceData);
+
+    const schedule = () => {
+      if (debounce.current) clearTimeout(debounce.current);
+      debounce.current = setTimeout(() => {
+        rebuild();
+        mirrorToOverlay(map, baseLayerId);
+      }, 100);
+    };
+    map.on("zoomend", schedule);
+    map.on("idle", () => mirrorToOverlay(map, baseLayerId));
+    map.on("styledata", () => mirrorToOverlay(map, baseLayerId));
+
+    function rebuild() {
+      // Build overlay for duplicates and receive the ids to hide in the parent
+      const allBasePoints = collectSourcePoints(map, baseLayerId);
+      const { pointsFc, linksFc, index, excludeIds } = buildSpiderDataOffsetOne(
+        map,
+        baseLayerId,
+        { features: allBasePoints }
+      );
+
+      // Persist index
+      if (!map.__spiderIndex) map.__spiderIndex = {};
+      map.__spiderIndex[baseLayerId] = index;
+
+      // Add/update sources
+      if (map.getSource(pointSourceId)) {
+        map.getSource(pointSourceId).setData(pointsFc);
+      } else {
+        map.addSource(pointSourceId, { type: "geojson", data: pointsFc });
+      }
+
+      if (map.getSource(linkSourceId)) {
+        map.getSource(linkSourceId).setData(linksFc);
+      } else {
+        map.addSource(linkSourceId, { type: "geojson", data: linksFc });
+      }
+
+      // Ensure overlay layers exist (we'll mirror the paint later)
+      if (!map.getLayer(linkLayerId)) {
+        map.addLayer({
+          id: linkLayerId,
+          type: "line",
+          source: linkSourceId,
+          paint: { "line-opacity": 0.7 },
+        });
+        try {
+          map.moveLayer(linkLayerId, baseLayerId);
+        } catch {}
+      }
+
+      if (!map.getLayer(pointLayerId)) {
+        map.addLayer({
+          id: pointLayerId,
+          type: "circle",
+          source: pointSourceId,
+          paint: {},
+        });
+        try {
+          map.moveLayer(pointLayerId, baseLayerId);
+        } catch {}
+      }
+
+      // Add hover/select for overlay
+      ensureSpiderHoverSelectLayers(map, baseLayerId);
+
+      // Initialise state: copy current state from parent to spider
+      // The mirror handles updates, but we need to copy the state that exists now.
+      const sourceLayer = getSourceLayer(map, baseLayerId);
+      
+      pointsFc.features.forEach((f) => {
+        // We use map.getFeatureState directly on the parent source.
+        // This is robust because we know the feature exists (we just collected it).
+        const parentState = map.getFeatureState({
+          source: baseLayerId,
+          sourceLayer: sourceLayer,
+          id: f.id
+        });
+
+        if (parentState) {
+          map.setFeatureState(
+            { source: pointSourceId, id: f.id },
+            parentState
+          );
+        }
+      });
+      
+      // Hide duplicates in parent (keeps exactly one visible per group)
+      // 
+      const idsChanged = 
+        excludeIds.length !== prevExcludeIds.current.length ||
+        excludeIds.some((id, i) => id !== prevExcludeIds.current[i]);
+
+      if (idsChanged) {
+        setDuplicateExclusionFilter(map, baseLayerId, excludeIds, baseFilterRef.current);
+        prevExcludeIds.current = excludeIds;
+      }
+    }
+
+    return () => {
+      if (!map || !map.style) return;
+
+      map.off("sourcedata", onSourceData);
+      map.off("zoomend", schedule);
+      map.off("idle", () => mirrorToOverlay(map, baseLayerId));
+      map.off("styledata", () => mirrorToOverlay(map, baseLayerId));
+      if (debounce.current) clearTimeout(debounce.current);
+
+      // Restore parent filter
+      try {
+        map.setFilter(baseLayerId, baseFilterRef.current);
+      } catch {}
+
+      // Remove overlay
+      if (map.getLayer(pointLayerId)) map.removeLayer(pointLayerId);
+      if (map.getSource(pointSourceId)) map.removeSource(pointSourceId);
+      if (map.getLayer(linkLayerId)) map.removeLayer(linkLayerId);
+      if (map.getSource(linkSourceId)) map.removeSource(linkSourceId);
+
+      // Remove hover/select layers for overlay
+      [`${baseLayerId}-spider-hover`, `${baseLayerId}-spider-select`].forEach(
+        (id) => {
+          if (map.getLayer(id)) map.removeLayer(id);
+        }
+      );
+      if (map.__spiderIndex) delete map.__spiderIndex[baseLayerId];
+    };
+  }, [map, baseLayerId]);
+
+  return null;
+}

--- a/packages/vis-core/src/Components/MapLayout/SpiderLayer.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/SpiderLayer.test.jsx
@@ -1,0 +1,189 @@
+/**
+ * @file SpiderLayer.test.jsx
+ * @description Comprehensive tests for the SpiderLayer React component.
+ */
+
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { SpiderLayer } from "./SpiderLayer";
+import { useMapContext } from "hooks";
+import {
+  ensureSpiderHoverSelectLayers,
+  buildSpiderDataOffsetOne,
+  collectSourcePoints,
+} from "utils/mapSpiders";
+
+// Mock dependencies
+jest.mock("hooks", () => ({
+  useMapContext: jest.fn(),
+}));
+
+jest.mock("utils", () => ({
+  getSourceLayer: jest.fn(() => "mock-source-layer"),
+}));
+
+jest.mock("utils/mapSpiders", () => ({
+  ensureSpiderHoverSelectLayers: jest.fn(),
+  buildSpiderDataOffsetOne: jest.fn(),
+  collectSourcePoints: jest.fn(),
+}));
+
+describe("SpiderLayer Component", () => {
+  let mockMap;
+  let mockMapContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    // Create a robust mock map object
+    mockMap = {
+      getLayer: jest.fn((id) => {
+        if (id === "baseLayer") return { type: "circle" };
+        return null;
+      }),
+      getSource: jest.fn(() => null),
+      addSource: jest.fn(),
+      addLayer: jest.fn(),
+      removeLayer: jest.fn(),
+      removeSource: jest.fn(),
+      moveLayer: jest.fn(),
+      on: jest.fn(),
+      off: jest.fn(),
+      getFilter: jest.fn(() => ["==", "type", "Point"]),
+      setFilter: jest.fn(),
+      getLayoutProperty: jest.fn(() => "visible"),
+      setLayoutProperty: jest.fn(),
+      getPaintProperty: jest.fn(() => 1),
+      setPaintProperty: jest.fn(),
+      getFeatureState: jest.fn(() => ({ hover: true })),
+      setFeatureState: jest.fn(),
+      style: {}, // Truthy style object to pass cleanup checks
+    };
+
+    mockMapContext = {
+      state: { map: mockMap },
+    };
+
+    useMapContext.mockReturnValue(mockMapContext);
+
+    // Default mock returns for mapSpiders utilities
+    collectSourcePoints.mockReturnValue([{ id: 1 }, { id: 2 }]);
+    buildSpiderDataOffsetOne.mockReturnValue({
+      pointsFc: { type: "FeatureCollection", features: [{ id: 2 }] },
+      linksFc: { type: "FeatureCollection", features: [{ id: 2 }] },
+      index: { 2: { overlayIds: [], linkIds: [] } },
+      excludeIds: [2],
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  /**
+   * Tests that the component correctly binds to map events on mount.
+   */
+  it("should bind map events on mount", () => {
+    render(<SpiderLayer baseLayerId="baseLayer" />);
+
+    expect(mockMap.on).toHaveBeenCalledWith("sourcedata", expect.any(Function));
+    expect(mockMap.on).toHaveBeenCalledWith("zoomend", expect.any(Function));
+    expect(mockMap.on).toHaveBeenCalledWith("idle", expect.any(Function));
+    expect(mockMap.on).toHaveBeenCalledWith("styledata", expect.any(Function));
+  });
+
+  /**
+   * Tests the debounced rebuild process triggered by map events.
+   */
+  it("should trigger rebuild and mirror properties on sourcedata event", async () => {
+    render(<SpiderLayer baseLayerId="baseLayer" />);
+
+    // Extract the sourcedata callback
+    const sourceDataCallback = mockMap.on.mock.calls.find(
+      (call) => call[0] === "sourcedata"
+    )[1];
+
+    // Simulate sourcedata event
+    sourceDataCallback({ sourceId: "baseLayer", isSourceLoaded: true });
+
+    // Fast-forward the 100ms debounce timer
+    jest.advanceTimersByTime(100);
+
+    await waitFor(() => {
+      // Verify spider data was built
+      expect(collectSourcePoints).toHaveBeenCalledWith(mockMap, "baseLayer");
+      expect(buildSpiderDataOffsetOne).toHaveBeenCalled();
+
+      // Verify sources and layers were added
+      expect(mockMap.addSource).toHaveBeenCalledWith("baseLayer-spider-src", expect.any(Object));
+      expect(mockMap.addSource).toHaveBeenCalledWith("baseLayer-spider-links-src", expect.any(Object));
+      expect(mockMap.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: "baseLayer-spider-links" }));
+      expect(mockMap.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: "baseLayer-spider" }));
+
+      // Verify duplicate exclusion filter was applied
+      expect(mockMap.setFilter).toHaveBeenCalledWith("baseLayer", [
+        "all",
+        ["==", "type", "Point"],
+        ["!", ["in", ["get", "id"], ["literal", [2]]]],
+      ]);
+
+      // Verify feature state was copied
+      expect(mockMap.setFeatureState).toHaveBeenCalledWith(
+        { source: "baseLayer-spider-src", id: 2 },
+        { hover: true }
+      );
+    });
+  });
+
+  /**
+   * Tests the cleanup function returned by useEffect.
+   */
+  it("should clean up layers, sources, and events on unmount", () => {
+    // Setup mock to pretend the base layer AND spider layers exist
+    mockMap.getLayer.mockImplementation((id) => {
+      // This prevents the early return in useEffect
+      if (id === "baseLayer") return { type: "circle" }; 
+      if (id.includes("spider")) return {};
+      return null;
+    });
+    
+    mockMap.getSource.mockImplementation((id) => id.includes("spider"));
+
+    const { unmount } = render(<SpiderLayer baseLayerId="baseLayer" />);
+
+    unmount();
+
+    // Verify event listeners are removed
+    expect(mockMap.off).toHaveBeenCalledWith("sourcedata", expect.any(Function));
+    expect(mockMap.off).toHaveBeenCalledWith("zoomend", expect.any(Function));
+    expect(mockMap.off).toHaveBeenCalledWith("idle", expect.any(Function));
+    expect(mockMap.off).toHaveBeenCalledWith("styledata", expect.any(Function));
+
+    // Verify original filter is restored
+    expect(mockMap.setFilter).toHaveBeenCalledWith("baseLayer", ["==", "type", "Point"]);
+
+    // Verify layers and sources are removed
+    expect(mockMap.removeLayer).toHaveBeenCalledWith("baseLayer-spider");
+    expect(mockMap.removeSource).toHaveBeenCalledWith("baseLayer-spider-src");
+    expect(mockMap.removeLayer).toHaveBeenCalledWith("baseLayer-spider-links");
+    expect(mockMap.removeSource).toHaveBeenCalledWith("baseLayer-spider-links-src");
+    expect(mockMap.removeLayer).toHaveBeenCalledWith("baseLayer-spider-hover");
+    expect(mockMap.removeLayer).toHaveBeenCalledWith("baseLayer-spider-select");
+
+    // Verify index is deleted
+    expect(mockMap.__spiderIndex).toBeUndefined();
+  });
+
+  /**
+   * Tests early return if the base layer does not exist or is not a circle type.
+   */
+  it("should do nothing if base layer is missing or not a circle", () => {
+    mockMap.getLayer.mockReturnValue(null); // Layer doesn't exist
+
+    render(<SpiderLayer baseLayerId="missingLayer" />);
+
+    expect(mockMap.on).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.jsx
@@ -1,511 +1,594 @@
-import React, { memo, useContext, useState, useEffect, useMemo, useRef } from "react";
-import styled from "styled-components";
-import {
-  EyeIcon,
-  EyeSlashIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-} from "@heroicons/react/20/solid";
-import { getOpacityProperty, getWidthProperty } from "utils";
-import { LayerSearch } from "./LayerSearch";
-import { ColourSchemeDropdown, BandEditor } from "../Selectors";
-import { ClassificationDropdown } from "../Selectors/ClassificationDropdown";
-import { AppContext, PageContext } from "contexts";
-import { calculateMaxWidthFactor, applyWidthFactor, updateOpacityExpression } from "utils/map"
-
-/**
- * Styled container for the layer control entry.
- */
-const LayerControlContainer = styled.div`
-  padding: 0.75rem;
-  margin-bottom: 0.75rem;
-  background-color: #fafafa;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-`;
-
-/**
- * Styled header for the layer control entry.
- */
-const LayerHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
-
-/**
- * Container for the left section of the header.
- * Made clickable to toggle expansion.
- */
-const HeaderLeft = styled.div`
-  display: flex;
-  align-items: center;
-  cursor: pointer; /* Make cursor a pointer to indicate clickability */
-`;
-
-/**
- * Styled span for expanding/collapsing layer details.
- */
-const ExpandCollapseToggle = styled.span`
-  display: flex;
-  align-items: center;
-  width: 24px;
-  height: 24px;
-  margin-right: 0.5rem;
-
-  svg {
-    width: 16px;
-    height: 16px;
-    color: #555;
-  }
-`;
-
-/**
- * Styled name for the layer.
- */
-const LayerName = styled.span`
-  font-weight: 600;
-  font-size: 1rem;
-  color: #333;
-`;
-
-/**
- * Styled button for toggling layer visibility.
- */
-const VisibilityToggle = styled.button`
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-
-  &:focus {
-    outline: 2px solid #005fcc;
-    outline-offset: 2px;
-  }
-
-  svg {
-    width: 24px;
-    height: 24px;
-    color: #555;
-  }
-`;
-
-/**
- * Styled container for the opacity control.
- */
-const OpacityControl = styled.div`
-  display: flex;
-  align-items: center;
-  margin-top: 5px;
-`;
-
-/**
- * Styled input for the slider.
- */
-const Slider = styled.input`
-  flex-grow: 1;
-  margin-right: 0.5rem;
-  cursor: pointer;
-
-  &:focus {
-    outline: none;
-  }
-`;
-
-/**
- * Styled label for form controls.
- */
-const ControlLabel = styled.label`
-  margin-right: 0.5rem;
-  font-size: 0.9rem;
-  color: #333;
-`;
-
-/**
- * Styled span for displaying the opacity value.
- */
-const SliderValue = styled.span`
-  font-size: 0.9rem;
-  width: 36px;
-  text-align: right;
-`;
-
-/**
- * Styled container for collapsible content with animation.
- */
-const CollapsibleContent = styled.div`
-  overflow: hidden;
-  max-height: ${({ isExpanded }) => (isExpanded ? "1000px" : "0")};
-  opacity: ${({ isExpanded }) => (isExpanded ? "1" : "0")};
-  transition: max-height 0.3s ease, opacity 0.3s ease;
-`;
-
-/**
- * Styled container for the width control.
- */
-const WidthControl = styled.div`
-  display: flex;
-  align-items: center;
-  margin-top: 5px;
-`;
-
-/**
- * Styled input for the width slider.
- */
-const WidthSlider = styled.input`
-  flex-grow: 1;
-  margin-right: 10px;
-`;
-
-/**
- * LayerControlEntry component represents a single layer control entry in the map layer control panel.
- *
- * @component
- * @param {Object} props - The component props.
- * @param {Object} props.layer - The layer object containing information about the map layer.
- * @param {Array} props.maps - An array of MapLibre map instances.
- * @param {Function} props.handleColorChange - The function to handle color changes for the layer.
- * @param {Function} props.handleClassificationChange - The function to handle classification changes for the layer.
- * @returns {JSX.Element} The rendered LayerControlEntry component.
- */
-export const LayerControlEntry = memo(
-  ({
-    layer,
-    maps,
-    handleColorChange,
-    handleClassificationChange,
-    state,
-  }) => {
-    const [visibility, setVisibility] = useState(
-      layer.layout?.visibility || "visible"
-    );
-
-    // State for whether the layer details are expanded
-    const [isExpanded, setIsExpanded] = useState(() => {
-      // Retrieve the expanded state from localStorage during initial render
-      const storedState = localStorage.getItem(
-        `layer-${layer.id}-isExpanded`
-      );
-      return storedState !== null ? JSON.parse(storedState) : true;
-    });
-
-    // Update localStorage whenever isExpanded changes
-    useEffect(() => {
-      localStorage.setItem(
-        `layer-${layer.id}-isExpanded`,
-        JSON.stringify(isExpanded)
-      );
-    }, [isExpanded, layer.id]);
-    const currentPage = useContext(PageContext);
-    const mapConfig = currentPage?.config?.map;
-    const defaultNodeWidthFactorFromPage = mapConfig?.defaultNodeWidthFactor;
-    const appConfig = useContext(AppContext);
-    const selectedMetricParamName = currentPage.config.filters.find(
-      (filter) => filter.containsLegendInfo === true
-    );
-    const selectedPageBands = appConfig.defaultBands.find((band) => {
-      if (!currentPage) return false;
-      const categoryOrName = currentPage.category || currentPage.pageName;
-      return band.name === categoryOrName;
-    });
-    const visualisation =
-      currentPage.pageName.includes("Side-by-Side") ||
-        currentPage.pageName.includes("Side by Side")
-        ? state.leftVisualisations[Object.keys(state.leftVisualisations)[0]]
-        : state.visualisations[Object.keys(state.visualisations)[0]];
-
-    const colorStyle = useMemo(() => {
-      // Use the resolved colorStyle from layer metadata if available, otherwise derive from visualization style
-      return layer.metadata?.colorStyle || visualisation?.style?.split("-")[1] || "continuous";
-    }, [layer.metadata?.colorStyle, visualisation?.style]);
-
-    const hasDefaultBands = selectedPageBands?.metric.find(
-      (metric) =>
-        metric.name ===
-        visualisation.queryParams[selectedMetricParamName.paramName]?.value
-    );
-
-    const shouldHaveOpacityControl = layer.metadata?.shouldHaveOpacityControl ?? true;
-    const enforceNoColourSchemeSelector = layer.metadata?.enforceNoColourSchemeSelector ?? false;
-    const enforceNoClassificationMethod = layer.metadata?.enforceNoClassificationMethod ?? false;
-    const widthProp = getWidthProperty(layer.type);
-    const enableZoomToFeature = layer.metadata?.enableZoomToFeature ?? Boolean(layer.metadata?.path);
-    const layerConfigFromState = state?.layers?.[layer.id];
-    const effectiveDefaultLineOffset =
-      layerConfigFromState?.defaultLineOffset ??
-      layer.metadata?.defaultLineOffset ??
-      layer.defaultLineOffset;
-
-    let currentWidthFactor = null;
-    let currentOpacity = null;
-
-    if (maps.length > 0 && maps[0].getLayer(layer.id)) {
-      const opacityProp = getOpacityProperty(layer.type);
-      currentOpacity = maps[0].getPaintProperty(layer.id, opacityProp);
-      currentWidthFactor = widthProp ? maps[0].getPaintProperty(layer.id, widthProp) : null;
-    }
-
-    const isFeatureStateExpression =
-      Array.isArray(currentOpacity) && currentOpacity[0] === "case";
-    const initialOpacity = isFeatureStateExpression
-      ? currentOpacity[currentOpacity.length - 1]
-      : currentOpacity;
-
-
-    const isFeatureStateWidthExpression =
-      Array.isArray(currentWidthFactor) && currentWidthFactor[0] === "interpolate";
-      const isNodeLayer = layer.type === "circle";  //station nodes are circle layers
-      const showWidth = isFeatureStateWidthExpression || isNodeLayer;
-    const initialWidth = isFeatureStateWidthExpression
-      ? calculateMaxWidthFactor(currentWidthFactor[currentWidthFactor.length - 1], widthProp)
-      : currentWidthFactor;
-
-    // State for opacity of the layer
-    const [opacity, setOpacity] = useState(initialOpacity || 0.5);
-    const desiredDefaultNodeWidth =
-      typeof defaultNodeWidthFactorFromPage === "number"
-        ? defaultNodeWidthFactorFromPage
-        : null;
-
-    const initialWidthForUI =
-      isNodeLayer && desiredDefaultNodeWidth != null
-        ? desiredDefaultNodeWidth
-        : (initialWidth || 1);
-
-    const [widthFactor, setWidth] = useState(initialWidthForUI);
-
+import React, { memo, useContext, useState, useEffect, useMemo, useRef } from "react";  
+import styled from "styled-components";  
+import {  
+  EyeIcon,  
+  EyeSlashIcon,  
+  ChevronDownIcon,  
+  ChevronRightIcon,  
+} from "@heroicons/react/20/solid";  
+import { getOpacityProperty, getWidthProperty } from "utils";  
+import { LayerSearch } from "./LayerSearch";  
+import { ColourSchemeDropdown, BandEditor } from "../Selectors";  
+import { ClassificationDropdown } from "../Selectors/ClassificationDropdown";  
+import { AppContext, PageContext } from "contexts";  
+import { calculateMaxWidthFactor, applyWidthFactor, updateOpacityExpression } from "utils/map"  
+  
+/**  
+* Styled container for the layer control entry.  
+*/  
+const LayerControlContainer = styled.div`  
+  padding: 0.75rem;  
+  margin-bottom: 0.75rem;  
+  background-color: #fafafa;  
+  border: 1px solid #ddd;  
+  border-radius: 4px;  
+`;  
+  
+/**  
+* Styled header for the layer control entry.  
+*/  
+const LayerHeader = styled.div`  
+  display: flex;  
+  justify-content: space-between;  
+  align-items: center;  
+`;  
+  
+  
+/**  
+* Container for the left section of the header.  
+* Made clickable to toggle expansion.  
+*/  
+const HeaderLeft = styled.div`  
+  display: flex;  
+  align-items: center;  
+  cursor: pointer; /* Make cursor a pointer to indicate clickability */  
+`;  
+  
+/**  
+* Styled span for expanding/collapsing layer details.  
+*/  
+const ExpandCollapseToggle = styled.span`  
+  display: flex;  
+  align-items: center;  
+  width: 24px;  
+  height: 24px;  
+  margin-right: 0.5rem;  
+  
+  svg {  
+    width: 16px;  
+    height: 16px;  
+    color: #555;  
+  }  
+`;  
+  
+/**  
+* Styled name for the layer.  
+*/  
+const LayerName = styled.span`  
+  font-weight: 600;  
+  font-size: 1rem;  
+  color: #333;  
+`;  
+  
+/**  
+* Styled button for toggling layer visibility.  
+*/  
+const VisibilityToggle = styled.button`  
+  background: transparent;  
+  border: none;  
+  cursor: pointer;  
+  padding: 0;  
+  display: flex;  
+  align-items: center;  
+  justify-content: center;  
+  width: 32px;  
+  height: 32px;  
+  
+  &:focus {  
+    outline: 2px solid #005fcc;  
+    outline-offset: 2px;  
+  }  
+  
+  svg {  
+    width: 24px;  
+    height: 24px;  
+    color: #555;  
+  }  
+`;  
+  
+/**  
+* Styled container for the opacity control.  
+*/  
+const OpacityControl = styled.div`  
+  display: flex;  
+  align-items: center;  
+  margin-top: 5px;  
+`;  
+  
+/**  
+* Styled input for the slider.  
+*/  
+const Slider = styled.input`  
+  flex-grow: 1;  
+  margin-right: 0.5rem;  
+  cursor: pointer;  
+  
+  &:focus {  
+    outline: none;  
+  }  
+`;  
+  
+/**  
+* Styled label for form controls.  
+*/  
+const ControlLabel = styled.label`  
+  margin-right: 0.5rem;  
+  font-size: 0.9rem;  
+  color: #333;  
+`;  
+  
+/**  
+* Styled span for displaying the opacity value.  
+*/  
+const SliderValue = styled.span`  
+  font-size: 0.9rem;  
+  width: 36px;  
+  text-align: right;  
+`;  
+  
+/**  
+* Styled container for collapsible content with animation.  
+*/  
+const CollapsibleContent = styled.div`  
+  overflow: hidden;  
+  max-height: ${({ isExpanded }) => (isExpanded ? "1000px" : "0")};  
+  opacity: ${({ isExpanded }) => (isExpanded ? "1" : "0")};  
+  transition: max-height 0.3s ease, opacity 0.3s ease;  
+`;  
+  
+/**  
+* Styled container for the width control.  
+*/  
+const WidthControl = styled.div`  
+  display: flex;  
+  align-items: center;  
+  margin-top: 5px;  
+`;  
+  
+/**  
+* Styled input for the width slider.  
+*/  
+const WidthSlider = styled.input`  
+  flex-grow: 1;  
+  margin-right: 10px;  
+`;  
+  
+/**  
+* LayerControlEntry component represents a single layer control entry in the map layer control panel.  
+*  
+* @component  
+* @param {Object} props - The component props.  
+* @param {Object} props.layer - The layer object containing information about the map layer.  
+* @param {Array} props.maps - An array of MapLibre map instances.  
+* @param {Function} props.handleColorChange - The function to handle color changes for the layer.  
+* @param {Function} props.handleClassificationChange - The function to handle classification changes for the layer.  
+* @param {Object} props.state - The current application state.
+* @returns {JSX.Element} The rendered LayerControlEntry component.  
+*/  
+export const LayerControlEntry = memo(  
+  ({  
+    layer,  
+    maps,  
+    handleColorChange,  
+    handleClassificationChange,  
+    state,  
+  }) => {  
+    const [visibility, setVisibility] = useState(  
+      layer.layout?.visibility || "visible"  
+    );  
+  
+    // State for whether the layer details are expanded  
+    const [isExpanded, setIsExpanded] = useState(() => {  
+      // Retrieve the expanded state from localStorage during initial render  
+      const storedState = localStorage.getItem(  
+        `layer-${layer.id}-isExpanded`  
+      );  
+      return storedState !== null ? JSON.parse(storedState) : true;  
+    });  
+  
+    /**  
+     * Builds a list of "linked" layer IDs that should mirror the base layer's  
+     * visibility and style changes (label + spider overlays).  
+     *  
+     * @param {maplibregl.Map} map - A MapLibre instance.  
+     * @param {string} baseId - The base layer id.  
+     * @returns {string[]} Array of linked layer ids present on the map.  
+     */  
+    function getLinkedLayerIds(map, baseId) {  
+      const candidates = [  
+        baseId,  
+        `${baseId}-label`,  
+        `${baseId}-spider`,  
+        `${baseId}-spider-links`,  
+      ];  
+      return candidates.filter((id) => map.getLayer(id));  
+    }  
+  
+    /**  
+     * Sets a paint property across all linked layers if the property exists  
+     * for that layer type. Falls back to the given value when an expression  
+     * cannot be updated safely.  
+     *  
+     * @param {maplibregl.Map} map  
+     * @param {string[]} ids - Layer ids to update.  
+     * @param {string} prop - Paint property name (e.g., 'circle-opacity').  
+     * @param {any} value - Value or expression to set.  
+     */  
+    function setPaintAcross(map, ids, prop, value) {  
+      ids.forEach((id) => {  
+        try {  
+          const current = map.getPaintProperty(id, prop);  
+          const next =  
+            prop.endsWith('opacity') && current !== undefined  
+              ? updateOpacityExpression(current, value)  
+              : value;  
+          map.setPaintProperty(id, prop, next);  
+        } catch {  
+          // silently ignore when a layer doesn't have that paint prop  
+        }  
+      });  
+    }  
+  
+    /**  
+     * Applies a width factor to any layer that has an 'interpolate' width expression.  
+     * If the expression is not present, it falls back to setting a numeric width.  
+     * Also updates line-offset when appropriate.  
+     *  
+     * @param {maplibregl.Map} map  
+     * @param {string[]} ids - Layer ids to update.  
+     * @param {string} paintProp - Width paint property (e.g., 'circle-radius'|'line-width').  
+     * @param {number} factor - Desired width factor.  
+     * @param {number|undefined} customOffset - Optional custom offset for line layers.  
+     */  
+    function setWidthAcross(map, ids, paintProp, factor, customOffset) {  
+      ids.forEach((id) => {  
+        try {  
+          const currentExpr = map.getPaintProperty(id, paintProp);  
+          if (Array.isArray(currentExpr) && currentExpr[0] === "interpolate") {  
+            const { widthInterpolation, lineOffsetInterpolation } =  
+              applyWidthFactor(currentExpr, factor, paintProp, customOffset);  
+            map.setPaintProperty(id, paintProp, widthInterpolation);  
+            if (paintProp === "line-width" && lineOffsetInterpolation) {  
+              map.setPaintProperty(id, "line-offset", lineOffsetInterpolation);  
+            }  
+          } else if (typeof currentExpr === "number") {  
+            // Simple numeric fallback: scale directly  
+            const baseline = typeof currentExpr === "number" ? currentExpr : 1;  
+            map.setPaintProperty(  
+              id,  
+              paintProp,  
+              Math.max(0.5, baseline * factor)  
+            );  
+          }  
+        } catch {  
+          // ignore if layer doesn't have that prop or setPaintProperty throws  
+        }  
+      });  
+    }  
+  
+    // Update localStorage whenever isExpanded changes  
+    useEffect(() => {  
+      localStorage.setItem(  
+        `layer-${layer.id}-isExpanded`,  
+        JSON.stringify(isExpanded)  
+      );  
+    }, [isExpanded, layer.id]);  
+    const currentPage = useContext(PageContext);  
+    const mapConfig = currentPage?.config?.map;  
+    const defaultNodeWidthFactorFromPage = mapConfig?.defaultNodeWidthFactor;  
+    const appConfig = useContext(AppContext);  
+    const selectedMetricParamName = currentPage.config.filters.find(  
+      (filter) => filter.containsLegendInfo === true  
+    );  
+    const selectedPageBands = appConfig.defaultBands.find((band) => {  
+      if (!currentPage) return false;  
+      const categoryOrName = currentPage.category || currentPage.pageName;  
+      return band.name === categoryOrName;  
+    });  
+    const visualisation =  
+      currentPage.pageName.includes("Side-by-Side") ||  
+        currentPage.pageName.includes("Side by Side")  
+        ? state.leftVisualisations[Object.keys(state.leftVisualisations)[0]]  
+        : state.visualisations[Object.keys(state.visualisations)[0]];  
+  
+    const colorStyle = useMemo(() => {  
+      // Use the resolved colorStyle from layer metadata if available, otherwise derive from visualization style  
+      return layer.metadata?.colorStyle || visualisation?.style?.split("-")[1] || "continuous";  
+    }, [layer.metadata?.colorStyle, visualisation?.style]);  
+  
+    const hasDefaultBands = selectedPageBands?.metric.find(  
+      (metric) =>  
+        metric.name ===  
+        visualisation.queryParams[selectedMetricParamName.paramName]?.value  
+    );  
+  
+    const shouldHaveOpacityControl = layer.metadata?.shouldHaveOpacityControl ?? true;  
+    const enforceNoColourSchemeSelector = layer.metadata?.enforceNoColourSchemeSelector ?? false;  
+    const enforceNoClassificationMethod = layer.metadata?.enforceNoClassificationMethod ?? false;  
+    const widthProp = getWidthProperty(layer.type);  
+    const enableZoomToFeature = layer.metadata?.enableZoomToFeature ?? Boolean(layer.metadata?.path);  
+    const layerConfigFromState = state?.layers?.[layer.id];  
+    const effectiveDefaultLineOffset =  
+      layerConfigFromState?.defaultLineOffset ??  
+      layer.metadata?.defaultLineOffset ??  
+      layer.defaultLineOffset;  
+  
+    let currentWidthFactor = null;  
+    let currentOpacity = null;  
+  
+    if (maps.length > 0 && maps[0].getLayer(layer.id)) {  
+      const opacityProp = getOpacityProperty(layer.type);  
+      currentOpacity = maps[0].getPaintProperty(layer.id, opacityProp);  
+      currentWidthFactor = widthProp ? maps[0].getPaintProperty(layer.id, widthProp) : null;  
+    }  
+  
+    const isFeatureStateExpression =  
+      Array.isArray(currentOpacity) && currentOpacity[0] === "case";  
+    const initialOpacity = isFeatureStateExpression  
+      ? currentOpacity[currentOpacity.length - 1]  
+      : currentOpacity;  
+  
+  
+    const isFeatureStateWidthExpression =  
+      Array.isArray(currentWidthFactor) && currentWidthFactor[0] === "interpolate";  
+      const isNodeLayer = layer.type === "circle";  //station nodes are circle layers  
+      const showWidth = isFeatureStateWidthExpression || isNodeLayer;  
+    const initialWidth = isFeatureStateWidthExpression  
+      ? calculateMaxWidthFactor(currentWidthFactor[currentWidthFactor.length - 1], widthProp)  
+      : currentWidthFactor;  
+  
+    // State for opacity of the layer  
+    const [opacity, setOpacity] = useState(initialOpacity || 0.5);  
+    const desiredDefaultNodeWidth =  
+      typeof defaultNodeWidthFactorFromPage === "number"  
+        ? defaultNodeWidthFactorFromPage  
+        : null;  
+  
+    const initialWidthForUI =  
+      isNodeLayer && desiredDefaultNodeWidth != null  
+        ? desiredDefaultNodeWidth  
+        : (initialWidth || 1);  
+  
+    const [widthFactor, setWidth] = useState(initialWidthForUI);  
+  
+    /**  
+     * Toggle both the layer and its label layer visibility across all maps.  
+     *  
+     * This flips the local `visibility` state and applies the same visibility to  
+     * the base layer and its "-label" companion (if present) so they remain in sync.  
+     */  
+    const toggleVisibility = () => {  
+      const newVisibility = visibility === "visible" ? "none" : "visible";  
+  
+      maps.forEach((map) => {  
+        const ids = getLinkedLayerIds(map, layer.id);  
+        ids.forEach((id) => {  
+          map.setLayoutProperty(id, "visibility", newVisibility);  
+        });  
+      });  
+  
+      setVisibility(newVisibility);  
+    };  
+  
+    const handleOpacityChange = (e) => {  
+      const newOpacity = parseFloat(e.target.value);  
+      const baseOpacityProp = getOpacityProperty(layer.type);  
+  
+      maps.forEach((map) => {  
+        const ids = getLinkedLayerIds(map, layer.id);  
+  
+        // Update base type opacity across all linked layers that share the prop  
+        setPaintAcross(map, ids, baseOpacityProp, newOpacity);  
+  
+        // Additionally, ensure spider link layer tracks opacity even if base is circle/fill  
+        // (link layer uses 'line-opacity' for connector visibility)  
+        if (ids.includes(`${layer.id}-spider-links`)) {  
+          setPaintAcross(map, [`${layer.id}-spider-links`], 'line-opacity', newOpacity);  
+        }  
+      });  
+  
+      setOpacity(newOpacity);  
+    };  
+  
+    /**  
+     * Handle keypress events for accessibility.  
+     * @param {Object} e - The event object.  
+     */  
+    const handleKeyPress = (e) => {  
+      if (e.key === "Enter" || e.key === " ") {  
+        setIsExpanded(!isExpanded);  
+        e.preventDefault();  
+      }  
+    };  
+  
     /**
-     * Toggle both the layer and its label layer visibility across all maps.
-     *
-     * This flips the local `visibility` state and applies the same visibility to
-     * the base layer and its "-label" companion (if present) so they remain in sync.
+     * Handles changes to the width factor slider.
+     * Applies the new width factor to the base layer and any linked layers (e.g., spider links).
+     * 
+     * @param {Object} e - The event object from the slider input.
      */
-    const toggleVisibility = () => {
-      const newVisibility = visibility === "visible" ? "none" : "visible";
-      const ids = [layer.id, `${layer.id}-label`];
-
-      maps.forEach((map) => {
-        ids.forEach((id) => {
-          if (map.getLayer(id)) {
-            map.setLayoutProperty(id, "visibility", newVisibility);
-          }
-        });
-      });
-
-      setVisibility(newVisibility);
-    };
-
-    const handleOpacityChange = (e) => {
-      const newOpacity = parseFloat(e.target.value);
-      const opacityProp = getOpacityProperty(layer.type);
-
-      maps.forEach((map) => {
-        if (map.getLayer(layer.id)) {
-          const currentExpr = map.getPaintProperty(layer.id, opacityProp);
-          const updatedExpr = updateOpacityExpression(currentExpr, newOpacity);
-          map.setPaintProperty(layer.id, opacityProp, updatedExpr);
-        }
-      });
-      setOpacity(newOpacity);
-    };
-
-    /**
-     * Handle keypress events for accessibility.
-     * @param {Object} e - The event object.
-     */
-    const handleKeyPress = (e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        setIsExpanded(!isExpanded);
-        e.preventDefault();
-      }
-    };
-
-    const handleWidthFactorChange = (e) => {
-      const raw = parseFloat(e.target.value);
-      const min = isNodeLayer ? 0.1 : 0.5;
-      const max = isNodeLayer ? 2.5 : 10;
-      const widthFactor = Math.max(min, Math.min(max, raw));
-      let widthInterpolation, lineOffsetInterpolation, widthExpression;
-      const hasDefaultLineOffset = effectiveDefaultLineOffset !== undefined && effectiveDefaultLineOffset !== null;
-
-      if (isFeatureStateWidthExpression) {
-        // Apply the width factor using the applyWidthFactor function
-        // Keep line-offset fixed to defaultLineOffset if provided
-        const result = applyWidthFactor(currentWidthFactor, widthFactor, widthProp);
-        widthInterpolation = result.widthInterpolation;
-        lineOffsetInterpolation = hasDefaultLineOffset ? null : result.lineOffsetInterpolation;
-      } else {
-        widthExpression = widthFactor; // Default width expression if not using feature-state
-      }
-
-      maps.forEach((map) => {
-        if (map.getLayer(layer.id)) {
-          // Set the width property
-          map.setPaintProperty(layer.id, widthProp, widthInterpolation || widthExpression);
-
-          // Set the line-offset property if applicable
-          if (widthProp.includes("line")) {
-            if (hasDefaultLineOffset) {
-              map.setPaintProperty(layer.id, "line-offset", effectiveDefaultLineOffset);
-            } else if (lineOffsetInterpolation) {
-              map.setPaintProperty(layer.id, "line-offset", lineOffsetInterpolation);
-            }
-          }
-        }
-      });
-
-      setWidth(widthFactor);
-    };
-
-    const appliedNodeDefaultRef = useRef(false);
-
-    useEffect(() => {
-      if (appliedNodeDefaultRef.current) return;
-      if (!maps?.length) return;
-      if (!isNodeLayer) return;
-      if (!widthProp) return;
-      if (isFeatureStateWidthExpression) return;
-
-      if (typeof desiredDefaultNodeWidth !== "number") return;
-
-      maps.forEach((map) => {
-        if (map?.getLayer?.(layer.id)) {
-          map.setPaintProperty(layer.id, widthProp, desiredDefaultNodeWidth);
-        }
-      });
-
-      setWidth(desiredDefaultNodeWidth);
-      appliedNodeDefaultRef.current = true;
-    }, [
-      maps,
-      layer.id,
-      isNodeLayer,
-      widthProp,
-      isFeatureStateWidthExpression,
-      desiredDefaultNodeWidth,
-    ]);
-
-
-    return (
-      <LayerControlContainer>
-        <LayerHeader>
-          {/* HeaderLeft now handles click and keypress to toggle expansion */}
-          <HeaderLeft
-            onClick={() => setIsExpanded(!isExpanded)}
-            role="button"
-            tabIndex="0"
-            aria-expanded={isExpanded}
-            onKeyDown={handleKeyPress}
-            data-testid="HeaderLeft"
-          >
-            {/* Expand/Collapse Toggle (now a span) */}
-            <ExpandCollapseToggle>
-              {isExpanded ? <ChevronDownIcon data-testid="ChevronDownIcon"/> : <ChevronRightIcon data-testid="ChevronRightIcon"/>}
-            </ExpandCollapseToggle>
-            {/* Layer Name */}
-            <LayerName>{layer.id}</LayerName>
-          </HeaderLeft>
-          {/* Visibility Toggle */}
-          <VisibilityToggle onClick={toggleVisibility} data-testid="visibility-toggle">
-            {visibility === "visible" ? (
-              <EyeIcon aria-label="Hide layer" title="Hide layer" />
-            ) : (
-              <EyeSlashIcon aria-label="Show layer" title="Show layer" />
-            )}
-          </VisibilityToggle>
-        </LayerHeader>
-        {/* Collapsible Content with Animation */}
-        <CollapsibleContent isExpanded={isExpanded}>
-          {/* Layer Search (if applicable) */}
-          {enableZoomToFeature && layer.metadata?.path && (
-            <LayerSearch map={maps[0]} layer={layer} />
-          )}
-          {/* Opacity Control */}
-          {shouldHaveOpacityControl && (<OpacityControl>
-            <ControlLabel htmlFor={`opacity-${layer.id}`}>
-              Opacity
-            </ControlLabel>
-            <Slider
-              id={`opacity-${layer.id}`}
-              type="range"
-              min="0"
-              max="1"
-              step="0.1"
-              value={opacity}
-              onChange={handleOpacityChange}
-            />
-            <SliderValue>{(opacity * 100).toFixed(0)}%</SliderValue>
-          </OpacityControl>)}
-          {/* Width Control (if applicable) */}
-          {showWidth && (
-            <WidthControl>
-              <ControlLabel htmlFor={`width-${layer.id}`}>Width factor</ControlLabel>
-              <Slider
-                id={`width-${layer.id}`}
-                data-testid="slider width factor"
-                type="range"
-                min={isNodeLayer ? 0.1 : 0.5}
-                max={isNodeLayer ? 2.5 : 10}   // 2.5 for nodes, 10 for links
-                step="0.1"
-                value={widthFactor}
-                onChange={handleWidthFactorChange}
-              />
-              <SliderValue>{widthFactor.toFixed(1)}</SliderValue>
-            </WidthControl>
-          )}
-          {/* Color Scheme, Band Editor, and Classification (if stylable) */}
-          {layer.metadata?.isStylable && (
-            <div style={{ marginTop: "1rem" }}>
-              {!enforceNoColourSchemeSelector &&
-                !((visualisation?.queryParams?.[selectedMetricParamName?.paramName]?.value === "Excess Seating" ||
-                  visualisation?.queryParams?.[selectedMetricParamName?.paramName]?.value === "Passengers Over Seating Capacity") &&
-                  (currentPage.pageName === "Link Totals" || currentPage.pageName === "Link Totals Side-by-Side")) &&
-                <ColourSchemeDropdown
-                  colorStyle={colorStyle}
-                  handleColorChange={handleColorChange}
-                  layerName={layer.id}
-                />}
-
-              {/* BandEditor for continuous/diverging only
-              {(colorStyle === "continuous" || colorStyle === "diverging") && hasDefaultBands && (
-                <BandEditor
-                  bands={hasDefaultBands.values}
-                  onChange={(newBands) => {
-                    // TODO: Implement update logic for bands in state and map/legend
-                    // Example: dispatch({ type: 'UPDATE_BANDS', layerId: layer.id, bands: newBands })
-                  }}
-                  isDiverging={colorStyle === "diverging"}
-                />
-              )} */}
-
-              {!enforceNoClassificationMethod && <ClassificationDropdown
-                classType={{
-                  ...(hasDefaultBands?.values && {Default: "d"}),
-                  Quantile: "q",
-                  Equidistant: "e",
-                  Logarithmic: "l",
-                  "K-Means": "k",
-                  "Jenks Natural Breaks": "j",
-                  "Standard Deviation": "s",
-                  "Head/Tail Breaks": "h",
-                }}
-                classification={
-                  state.layers[layer.id]?.class_method ?? "d"
-                }
-                onChange={(value) =>
-                  handleClassificationChange(value, layer.id)
-                }
-              />}
-            </div>
-          )}
-        </CollapsibleContent>
-      </LayerControlContainer>
-    );
-  }
-);
+    const handleWidthFactorChange = (e) => {  
+      const raw = parseFloat(e.target.value);  
+      const min = isNodeLayer ? 0.1 : 0.5;  
+      const max = isNodeLayer ? 2.5 : 10;  
+      const nextFactor = Math.max(min, Math.min(max, raw));  
+  
+      const baseWidthProp = getWidthProperty(layer.type);  
+      
+      // Use the robust effectiveDefaultLineOffset from the current branch
+      const customOffset = effectiveDefaultLineOffset !== undefined && effectiveDefaultLineOffset !== null 
+        ? effectiveDefaultLineOffset 
+        : undefined;
+  
+      maps.forEach((map) => {  
+        const ids = getLinkedLayerIds(map, layer.id);  
+  
+        // Apply factor to all linked layers that share the same paint prop  
+        setWidthAcross(map, ids, baseWidthProp, nextFactor, customOffset);  
+  
+        // Ensure spider link layer’s line-width follows too (for point layers with connectors)  
+        const linkId = `${layer.id}-spider-links`;  
+        if (ids.includes(linkId)) {  
+          setWidthAcross(map, [linkId], 'line-width', nextFactor, customOffset);  
+        }  
+      });  
+  
+      setWidth(nextFactor);  
+    };  
+  
+    const appliedNodeDefaultRef = useRef(false);  
+  
+    useEffect(() => {  
+      if (appliedNodeDefaultRef.current) return;  
+      if (!maps?.length) return;  
+      if (!isNodeLayer) return;  
+      if (!widthProp) return;  
+      if (isFeatureStateWidthExpression) return;  
+  
+      if (typeof desiredDefaultNodeWidth !== "number") return;  
+  
+      maps.forEach((map) => {  
+        if (map?.getLayer?.(layer.id)) {  
+          map.setPaintProperty(layer.id, widthProp, desiredDefaultNodeWidth);  
+        }  
+      });  
+  
+      setWidth(desiredDefaultNodeWidth);  
+      appliedNodeDefaultRef.current = true;  
+    }, [  
+      maps,  
+      layer.id,  
+      isNodeLayer,  
+      widthProp,  
+      isFeatureStateWidthExpression,  
+      desiredDefaultNodeWidth,  
+    ]);  
+  
+  
+    return (  
+      <LayerControlContainer>  
+        <LayerHeader>  
+          {/* HeaderLeft now handles click and keypress to toggle expansion */}  
+          <HeaderLeft  
+            onClick={() => setIsExpanded(!isExpanded)}  
+            role="button"  
+            tabIndex="0"  
+            aria-expanded={isExpanded}  
+            onKeyDown={handleKeyPress}  
+            data-testid="HeaderLeft"  
+          >  
+            {/* Expand/Collapse Toggle (now a span) */}  
+            <ExpandCollapseToggle>  
+              {isExpanded ? <ChevronDownIcon data-testid="ChevronDownIcon"/> : <ChevronRightIcon data-testid="ChevronRightIcon"/>}  
+            </ExpandCollapseToggle>  
+            {/* Layer Name */}  
+            <LayerName>{layer.id}</LayerName>  
+          </HeaderLeft>  
+          {/* Visibility Toggle */}  
+          <VisibilityToggle onClick={toggleVisibility} data-testid="visibility-toggle">  
+            {visibility === "visible" ? (  
+              <EyeIcon aria-label="Hide layer" title="Hide layer" />  
+            ) : (  
+              <EyeSlashIcon aria-label="Show layer" title="Show layer" />  
+            )}  
+          </VisibilityToggle>  
+        </LayerHeader>  
+        {/* Collapsible Content with Animation */}  
+        <CollapsibleContent isExpanded={isExpanded}>  
+          {/* Layer Search (if applicable) */}  
+          {enableZoomToFeature && layer.metadata?.path && (  
+            <LayerSearch map={maps[0]} layer={layer} />  
+          )}  
+          {/* Opacity Control */}  
+          {shouldHaveOpacityControl && (<OpacityControl>  
+            <ControlLabel htmlFor={`opacity-${layer.id}`}>  
+              Opacity  
+            </ControlLabel>  
+            <Slider  
+              id={`opacity-${layer.id}`}  
+              type="range"  
+              min="0"  
+              max="1"  
+              step="0.1"  
+              value={opacity}  
+              onChange={handleOpacityChange}  
+            />  
+            <SliderValue>{(opacity * 100).toFixed(0)}%</SliderValue>  
+          </OpacityControl>)}  
+          {/* Width Control (if applicable) */}  
+          {showWidth && (  
+            <WidthControl>  
+              <ControlLabel htmlFor={`width-${layer.id}`}>Width factor</ControlLabel>  
+              <Slider  
+                id={`width-${layer.id}`}  
+                data-testid="slider width factor"  
+                type="range"  
+                min={isNodeLayer ? 0.1 : 0.5}  
+                max={isNodeLayer ? 2.5 : 10}   // 2.5 for nodes, 10 for links  
+                step="0.1"  
+                value={widthFactor}  
+                onChange={handleWidthFactorChange}  
+              />  
+              <SliderValue>{widthFactor.toFixed(1)}</SliderValue>  
+            </WidthControl>  
+          )}  
+          {/* Color Scheme, Band Editor, and Classification (if stylable) */}  
+          {layer.metadata?.isStylable && (  
+            <div style={{ marginTop: "1rem" }}>  
+              {!enforceNoColourSchemeSelector &&  
+                !((visualisation?.queryParams?.[selectedMetricParamName?.paramName]?.value === "Excess Seating" ||  
+                  visualisation?.queryParams?.[selectedMetricParamName?.paramName]?.value === "Passengers Over Seating Capacity") &&  
+                  (currentPage.pageName === "Link Totals" || currentPage.pageName === "Link Totals Side-by-Side")) &&  
+                <ColourSchemeDropdown  
+                  colorStyle={colorStyle}  
+                  handleColorChange={handleColorChange}  
+                  layerName={layer.id}  
+                />}  
+  
+              {/* BandEditor for continuous/diverging only  
+              {(colorStyle === "continuous" || colorStyle === "diverging") && hasDefaultBands && (  
+                <BandEditor  
+                  bands={hasDefaultBands.values}  
+                  onChange={(newBands) => {  
+                    // TODO: Implement update logic for bands in state and map/legend  
+                    // Example: dispatch({ type: 'UPDATE_BANDS', layerId: layer.id, bands: newBands })  
+                  }}  
+                  isDiverging={colorStyle === "diverging"}  
+                />  
+              )} */}  
+  
+              {!enforceNoClassificationMethod && <ClassificationDropdown  
+                classType={{  
+                  ...(hasDefaultBands?.values && {Default: "d"}),  
+                  Quantile: "q",  
+                  Equidistant: "e",  
+                  Logarithmic: "l",  
+                  "K-Means": "k",  
+                  "Jenks Natural Breaks": "j",  
+                  "Standard Deviation": "s",  
+                  "Head/Tail Breaks": "h",  
+                }}  
+                classification={  
+                  state.layers[layer.id]?.class_method ?? "d"  
+                }  
+                onChange={(value) =>  
+                  handleClassificationChange(value, layer.id)  
+                }  
+              />}  
+            </div>  
+          )}  
+        </CollapsibleContent>  
+      </LayerControlContainer>  
+    );  
+  }  
+);  

--- a/packages/vis-core/src/Components/Sidebar/Accordion/MapLayerSection.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Accordion/MapLayerSection.jsx
@@ -35,6 +35,8 @@ export const MapLayerSection = ({
             !layer.id.endsWith("-hover") &&
             !layer.id.endsWith("-select") &&
             !layer.id.endsWith("-label") &&
+            !layer.id.endsWith("-spider") &&
+            !layer.id.endsWith("-spider-links") &&
             layer.id !== "selected-feature-layer" &&
             !layer.id.startsWith("hide_") &&
             !layer.id.startsWith("gl-draw")

--- a/packages/vis-core/src/utils/index.js
+++ b/packages/vis-core/src/utils/index.js
@@ -14,3 +14,5 @@ export * from './tooltip'
 export * from './filterPersistence'
 export * from './getByPath'
 export * from './openApiValidation'
+
+export * from './mapSpiders'

--- a/packages/vis-core/src/utils/mapSpiders.js
+++ b/packages/vis-core/src/utils/mapSpiders.js
@@ -1,0 +1,252 @@
+import { getSelectedLayerStyle, getHoverLayerStyle, getSourceLayer } from "./map";
+
+/**
+ * Collects all currently loaded point features for a vector-tile source,
+ * bypassing the parent layer’s filter. Dedupes by feature id.
+ *
+ * @param {maplibregl.Map} map
+ * @param {string} baseLayerId
+ * @returns {Array<maplibregl.MapboxGeoJSONFeature>}
+ */
+export function collectSourcePoints(map, baseLayerId) {
+  const sourceLayer = getSourceLayer(map, baseLayerId);
+  if (!sourceLayer) return [];
+  const perTile = map.querySourceFeatures(baseLayerId, { sourceLayer });
+  const seen = new Set();
+  return perTile.filter(f => {
+    if (!f.geometry || f.geometry.type !== 'Point') return false;
+    if (seen.has(f.id)) return false;
+    seen.add(f.id);
+    return true;
+  });
+}
+
+
+/**
+ * Computes screen-pixel offsets for N coincident points arranged on rings.
+ *
+ * - If count === 1, return a single offset straight "north" (0, -spacingPx) so the lone
+ *   item visibly separates from its anchor.
+ * - For count > 1, place points in concentric rings, starting from a configurable
+ *   start angle (default -90° = north), cascading around the circle.
+ *
+ * @param {number} count - Number of points to offset.
+ * @param {number} spacingPx - Pixel spacing between items on the ring (per ring radius).
+ * @param {number} startAngleDeg - Angle in degrees for the first offset; -90 means "north".
+ * @param {number} ringSlots0 - Number of slots on the first ring (subsequent rings add +4 each).
+ * @returns {Array<[number, number]>} Offsets in screen pixels [dx, dy] for each item.
+ */
+export function computeRingOffsets(count, spacingPx = 8, startAngleDeg = -90, ringSlots0 = 8) {
+  const toRad = (deg) => (deg * Math.PI) / 180;
+
+  if (count <= 0) return [];
+
+  // Single item: offset straight north so it’s visibly separated.
+  if (count === 1) {
+    return [[0, -Math.round(spacingPx)]];
+  }
+
+  const offsets = [];
+  let placed = 0;
+  let ring = 1;
+  const start = toRad(startAngleDeg);
+
+  while (placed < count) {
+    const slots = Math.floor(ringSlots0 + (ring - 1) * 4);
+    const radius = ring * spacingPx;
+
+    for (let s = 0; s < slots && placed < count; s += 1, placed += 1) {
+      const t = start + (2 * Math.PI * s) / slots;
+      const dx = Math.round(radius * Math.cos(t));
+      const dy = Math.round(radius * Math.sin(t)); // with start=-90°, first point goes north (negative y)
+      offsets.push([dx, dy]);
+    }
+
+    ring += 1;
+  }
+
+  return offsets;
+}
+
+/**
+ * Compute spider leg spacing in px.
+ *
+ * @param {number} gapPx     – a hard-coded buffer (e.g. 2× your circle radius)
+ * @param {number} basePx    – the "soft" spacing that is scaled by zoom
+ * @param {number} zoom      – current map zoom level
+ * @param {number} minZoom   – below this, spacing = minScale
+ * @param {number} maxZoom   – above this, spacing = maxScale
+ * @param {number} minScale  – scale factor at minZoom
+ * @param {number} maxScale  – scale factor at maxZoom
+ * 
+ * @returns {number}
+ *
+ * As zoom increases, the scale factor increases linearly, so points move further apart.
+ */
+export function spacingPxFromZoom(
+  zoom,
+  basePx = 16,
+  gapPx = 0,
+  minZoom = 6,
+  maxZoom = 18,
+  minScale = 0.1,
+  maxScale = 5.0
+) {
+  // clamp zoom into [minZoom…maxZoom]
+  const z = Math.max(minZoom, Math.min(maxZoom, zoom));
+
+  // t tells us how far between minZoom and maxZoom we are
+  const t = (z - minZoom) / (maxZoom - minZoom);
+
+  // linearly interpolate scale between minScale and maxScale
+  const scale = minScale + t * (maxScale - minScale);
+
+  // final spacing = fixed gap + zoom-scaled basePx
+  return Math.round(gapPx + basePx * scale);
+}
+
+/**
+ * Builds spider overlay data in "offsetOne" mode:
+ * - For each coincident group, select a single anchor to keep visible in the parent (min id),
+ * - Offset all other members into the overlay (with connectors),
+ * - Return a flat list of ids to hide in the parent (excludeIds).
+ *
+ * @param {maplibregl.Map} map
+ * @param {string} layerId
+ * @param {{ spacingPx?: number }} [options]
+ * @returns {{
+ *   pointsFc: GeoJSON.FeatureCollection,
+ *   linksFc: GeoJSON.FeatureCollection,
+ *   index: Record<string, { overlayIds: string[], linkIds: string[] }>,
+ *   excludeIds: (number|string)[]
+ * }}
+ */
+export function buildSpiderDataOffsetOne(map, layerId, options = {}) {
+  const features = Array.isArray(options.features)
+    ? options.features
+    : (() => {
+        // Unfiltered, per-tile features (bypasses layer filter)
+        const sourceLayer = getSourceLayer(map, layerId);
+        const perTile = sourceLayer ? map.querySourceFeatures(layerId, { sourceLayer }) : [];
+        // Deduplicate by id and keep points only
+        const seen = new Set();
+        return perTile.filter(f => {
+          if (!f.geometry || f.geometry.type !== 'Point') return false;
+          if (seen.has(f.id)) return false;
+          seen.add(f.id);
+          return true;
+        });
+      })();
+
+  // Group by identical coordinates
+  const byCoord = new Map();
+  const keyOf = (c) => `${c[0].toFixed(7)}|${c[1].toFixed(7)}`;
+  for (const f of features) {
+    if (!f.geometry || f.geometry.type !== 'Point') continue;
+    const key = keyOf(f.geometry.coordinates);
+    if (!byCoord.has(key)) byCoord.set(key, []);
+    byCoord.get(key).push(f);
+  }
+
+  const points = [];
+  const links = [];
+  const index = {};
+  const excludeIds = [];
+  const spacingPx = spacingPxFromZoom(map.getZoom(), options.spacingPx ?? 8);
+
+  for (const group of byCoord.values()) {
+    if (group.length <= 1) continue;
+
+    // Pick a deterministic anchor to keep in the parent (min id)
+    const sorted = [...group].sort((a, b) => (a.id > b.id ? 1 : -1));
+    const anchor = sorted[0];
+    const anchorCoord = anchor.geometry.coordinates;
+    const basePx = map.project(anchorCoord);
+
+    // Everyone but the anchor is offset into the overlay
+    const duplicates = sorted.slice(1);
+    excludeIds.push(...duplicates.map((f) => f.id));
+
+    // Build ring offsets for duplicates only
+    const count = duplicates.length;
+    const offsets = computeRingOffsets(count, spacingPx);
+    duplicates.forEach((f, idx) => {
+      const [dx, dy] = offsets[idx];
+      const p2 = { x: basePx.x + dx, y: basePx.y + dy };
+      const lngLat2 = map.unproject(p2);
+      const overlayId = `${layerId}:overlay:${String(f.id)}:${idx}`;
+      const linkId = `${layerId}:link:${String(f.id)}:${idx}`;
+
+      points.push({
+        type: 'Feature',
+        id: f.id,
+        properties: { ...f.properties, __origId: f.id },
+        geometry: { type: 'Point', coordinates: [lngLat2.lng, lngLat2.lat] }
+      });
+      links.push({
+        type: 'Feature',
+        id: f.id,
+        properties: { __origId: f.id },
+        geometry: { type: 'LineString', coordinates: [anchorCoord, [lngLat2.lng, lngLat2.lat]] }
+      });
+
+      if (!index[f.id]) index[f.id] = { overlayIds: [], linkIds: [] };
+      index[f.id].overlayIds.push(overlayId);
+      index[f.id].linkIds.push(linkId);
+    });
+  }
+
+  return {
+    pointsFc: { type: 'FeatureCollection', features: points },
+    linksFc:  { type: 'FeatureCollection', features: links },
+    index,
+    excludeIds
+  };
+}
+
+/**
+ * Returns overlay layer ids (points and links) for a given base layer if present.
+ * Use this to include spider overlays in centralised hover/select queries.
+ *
+ * @param {maplibregl.Map} map
+ * @param {string} layerId
+ * @returns {string[]} Array of overlay layer ids.
+ */
+export function getSpiderOverlayLayerIds(map, layerId) {
+  const ids = [];
+  const pointsId = `${layerId}-spider`;
+  const linksId = `${layerId}-spider-links`;
+  if (map.getLayer(pointsId)) ids.push(pointsId);
+  if (map.getLayer(linksId)) ids.push(linksId);
+  return ids;
+}
+
+/**
+ * Adds hover and select layers for the spider overlay points.
+ *
+ * @param {maplibregl.Map} map - MapLibre instance
+ * @param {string} baseLayerId - Parent layer id (e.g., "Stations")
+ */
+export function ensureSpiderHoverSelectLayers(map, baseLayerId) {
+  const pointSrcId = `${baseLayerId}-spider-src`;
+  const pointHoverId  = `${baseLayerId}-spider-hover`;
+  const pointSelectId = `${baseLayerId}-spider-select`;
+
+  // Points hover
+  if (!map.getLayer(pointHoverId) && map.getSource(pointSrcId)) {
+    const hoverLayer = getHoverLayerStyle('point');
+    hoverLayer.id = pointHoverId;
+    hoverLayer.source = pointSrcId;
+    hoverLayer.metadata = { isStylable: false };
+    map.addLayer(hoverLayer);
+  }
+
+  // Points select
+  if (!map.getLayer(pointSelectId) && map.getSource(pointSrcId)) {
+    const selectLayer = getSelectedLayerStyle('point');
+    selectLayer.id = pointSelectId;
+    selectLayer.source = pointSrcId;
+    selectLayer.metadata = { isStylable: false };
+    map.addLayer(selectLayer);
+  }
+}

--- a/packages/vis-core/src/utils/mapSpiders.test.js
+++ b/packages/vis-core/src/utils/mapSpiders.test.js
@@ -1,0 +1,191 @@
+/**
+ * @file mapSpiders.test.js
+ * @description Comprehensive unit tests for the mapSpiders utility functions.
+ */
+
+import {
+  collectSourcePoints,
+  computeRingOffsets,
+  spacingPxFromZoom,
+  buildSpiderDataOffsetOne,
+  getSpiderOverlayLayerIds,
+  ensureSpiderHoverSelectLayers,
+} from "./mapSpiders";
+
+// Import the module as a namespace to avoid destructuring issues
+import * as mapUtils from "./map";
+
+// Mock the module and explicitly declare it as an ES Module
+jest.mock("./map", () => ({
+  __esModule: true,
+  getSelectedLayerStyle: jest.fn(() => ({ type: "circle", paint: {} })),
+  getHoverLayerStyle: jest.fn(() => ({ type: "circle", paint: {} })),
+  getSourceLayer: jest.fn(),
+}));
+
+describe("mapSpiders utilities", () => {
+  let mockMap;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Access the mocked functions via the namespace and return valid objects
+    mapUtils.getSourceLayer.mockReturnValue("mock-source-layer");
+    mapUtils.getHoverLayerStyle.mockReturnValue({ type: "circle", paint: {} });
+    mapUtils.getSelectedLayerStyle.mockReturnValue({ type: "circle", paint: {} });
+
+    mockMap = {
+      querySourceFeatures: jest.fn(),
+      getZoom: jest.fn().mockReturnValue(10),
+      project: jest.fn((coord) => ({ x: coord[0] * 10, y: coord[1] * 10 })),
+      unproject: jest.fn((point) => ({ lng: point.x / 10, lat: point.y / 10 })),
+      getLayer: jest.fn(),
+      getSource: jest.fn(),
+      addLayer: jest.fn(),
+    };
+  });
+
+  describe("collectSourcePoints", () => {
+    it("should collect and deduplicate point features only", () => {
+      mockMap.querySourceFeatures.mockReturnValue([
+        { id: 1, geometry: { type: "Point" } },
+        { id: 2, geometry: { type: "LineString" } },
+        { id: 1, geometry: { type: "Point" } },
+        { id: 3, geometry: { type: "Point" } },
+      ]);
+
+      const result = collectSourcePoints(mockMap, "base-layer");
+      
+      expect(result).toHaveLength(2);
+      expect(result.map((f) => f.id)).toEqual([1, 3]);
+      expect(mockMap.querySourceFeatures).toHaveBeenCalledWith("base-layer", {
+        sourceLayer: "mock-source-layer",
+      });
+    });
+
+    it("should return empty array if sourceLayer is not found", () => {
+      // Override the mock for this specific test using the namespace
+      mapUtils.getSourceLayer.mockReturnValueOnce(null);
+      
+      const result = collectSourcePoints(mockMap, "base-layer");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("computeRingOffsets", () => {
+    /**
+     * Tests the mathematical offset generation for spider legs.
+     */
+    it("should return a single north offset for count === 1", () => {
+      const offsets = computeRingOffsets(1, 10);
+      expect(offsets).toEqual([[0, -10]]);
+    });
+
+    it("should return concentric ring offsets for count > 1", () => {
+      const offsets = computeRingOffsets(5, 10, -90, 4);
+      expect(offsets).toHaveLength(5);
+      // First point of the first ring (startAngle = -90) should be North (0, -10)
+      expect(offsets[0][0]).toBeCloseTo(0);
+      expect(offsets[0][1]).toBeCloseTo(-10);
+    });
+
+    it("should return empty array for count <= 0", () => {
+      expect(computeRingOffsets(0)).toEqual([]);
+      expect(computeRingOffsets(-5)).toEqual([]);
+    });
+  });
+
+  describe("spacingPxFromZoom", () => {
+    /**
+     * Tests the linear interpolation of pixel spacing based on zoom levels.
+     */
+    it("should clamp to minZoom and return minScale spacing", () => {
+      // zoom 4 is below minZoom 6
+      const spacing = spacingPxFromZoom(4, 16, 0, 6, 18, 0.1, 5.0);
+      expect(spacing).toBe(Math.round(16 * 0.1));
+    });
+
+    it("should clamp to maxZoom and return maxScale spacing", () => {
+      // zoom 20 is above maxZoom 18
+      const spacing = spacingPxFromZoom(20, 16, 0, 6, 18, 0.1, 5.0);
+      expect(spacing).toBe(Math.round(16 * 5.0));
+    });
+
+    it("should interpolate correctly for mid zoom", () => {
+      // zoom 12 is exactly halfway between 6 and 18
+      const spacing = spacingPxFromZoom(12, 16, 0, 6, 18, 0.1, 5.0);
+      const expectedScale = 0.1 + 0.5 * (5.0 - 0.1); // 2.55
+      expect(spacing).toBe(Math.round(16 * expectedScale));
+    });
+  });
+
+  describe("buildSpiderDataOffsetOne", () => {
+    /**
+     * Tests the core spiderfication logic: grouping coincident points,
+     * keeping one anchor, and offsetting the rest.
+     */
+    it("should group coincident points, offset duplicates, and return excludeIds", () => {
+      const features = [
+        { id: 1, properties: { name: "A" }, geometry: { type: "Point", coordinates: [10, 20] } },
+        { id: 2, properties: { name: "B" }, geometry: { type: "Point", coordinates: [10, 20] } }, // Coincident
+        { id: 3, properties: { name: "C" }, geometry: { type: "Point", coordinates: [30, 40] } }, // Separate
+      ];
+
+      const result = buildSpiderDataOffsetOne(mockMap, "test-layer", { features, spacingPx: 10 });
+
+      // Only feature 2 should be excluded (feature 1 is the anchor because 1 < 2)
+      expect(result.excludeIds).toEqual([2]);
+      
+      // One point and one link should be generated for the duplicate
+      expect(result.pointsFc.features).toHaveLength(1);
+      expect(result.linksFc.features).toHaveLength(1);
+      
+      // Check index generation
+      expect(result.index[2]).toBeDefined();
+      expect(result.index[2].overlayIds[0]).toBe("test-layer:overlay:2:0");
+      expect(result.index[2].linkIds[0]).toBe("test-layer:link:2:0");
+    });
+  });
+
+  describe("getSpiderOverlayLayerIds", () => {
+    /**
+     * Tests retrieval of overlay layer IDs if they exist on the map.
+     */
+    it("should return layer IDs that exist on the map", () => {
+      mockMap.getLayer.mockImplementation((id) => id === "base-spider");
+      
+      const ids = getSpiderOverlayLayerIds(mockMap, "base");
+      expect(ids).toEqual(["base-spider"]); // links layer doesn't exist in mock
+    });
+  });
+
+  describe("ensureSpiderHoverSelectLayers", () => {
+    /**
+     * Tests that hover and select layers are added if the source exists
+     * and the layers do not already exist.
+     */
+    it("should add hover and select layers if they do not exist", () => {
+      mockMap.getLayer.mockReturnValue(false); // Layers don't exist
+      mockMap.getSource.mockReturnValue(true); // Source exists
+
+      ensureSpiderHoverSelectLayers(mockMap, "base");
+
+      expect(mockMap.addLayer).toHaveBeenCalledTimes(2);
+      expect(mockMap.addLayer).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "base-spider-hover", source: "base-spider-src" })
+      );
+      expect(mockMap.addLayer).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "base-spider-select", source: "base-spider-src" })
+      );
+    });
+
+    it("should not add layers if source does not exist", () => {
+      mockMap.getLayer.mockReturnValue(false);
+      mockMap.getSource.mockReturnValue(false); // Source missing
+
+      ensureSpiderHoverSelectLayers(mockMap, "base");
+
+      expect(mockMap.addLayer).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR implements a feature which 'spiderfies' overlapping points in a map layer by
- identifying overlaps
- creating sibling, GeoJSON layers for the overlapping points (and select/hover)
- calculating an offset, starting at 0deg and cascading in a circle
- mirroring styles and featureState from the sibling layer
- recalculating the offset based on zoom level.

Core logic is split from the main Layer/Map, apart from some specific logic which needs to be handled by map (for instance, cascading custom tooltip functionality through to the spider layer).

This uses GeoJSON -- for layers with many thousands of points (e.g. NoHAM nodes), the functionality will be a bit shaky, and we should think about implementing something else.

NB previously implemented and approved in TAME-Vis-React-Template PR [#545](https://github.com/Transport-for-the-North/TAME-Vis-React-Template/pull/545) for issue [#540](https://github.com/Transport-for-the-North/TAME-Vis-React-Template/issues/540)
