### PR TITLE
Update transformIgnorePatterns for Jest

### DIFF
--- a/packages/vis-core/jest.config.js
+++ b/packages/vis-core/jest.config.js
@@ -40,6 +40,9 @@ export default {
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(@turf|kdbush|mapbox-gl|@mapbox/mapbox-gl-draw|@mapbox/mapbox-gl-geocoder)/)',
+  ],
   testMatch: [
     '**/__tests__/**/*.[jt]s?(x)',
     '**/?(*.)+(spec|test).[jt]s?(x)'


### PR DESCRIPTION
Adjust the `transformIgnorePatterns` in Jest configuration to include specific modules, preventing errors in CI/CD with Turf. No changes to tests or documentation were made.

# Changes

*Updated Jest configuration to include specific modules in `transformIgnorePatterns` to prevent CI/CD errors.*