### PR TITLE
User-changing line width functionality

### DIFF
--- a/packages/vis-core/src/Components/MapLayout/Layer.jsx
+++ b/packages/vis-core/src/Components/MapLayout/Layer.jsx
@@ -128,6 +128,11 @@ export const Layer = ({ layer }) => {
           shouldHaveOpacityControl: layer.shouldHaveOpacityControl ?? true, // opacity control should appear by default
           enforceNoColourSchemeSelector: layer.enforceNoColourSchemeSelector ?? false, // colour scheme selector should appear if stylable, unless this is enforced
           enforceNoClassificationMethod: layer.enforceNoClassificationMethod ?? false, // classification method selector should appear if stylable, unless this is enforced
+          fixLineWidth: layer.fixLineWidth ?? false,
+          fixedLineWidth:
+            typeof layer.fixedLineWidth === "number" && Number.isFinite(layer.fixedLineWidth)
+              ? layer.fixedLineWidth
+              : null,
           zoomToFeaturePlaceholderText: layer.zoomToFeaturePlaceholderText || "",
           defaultOpacity: layer.defaultOpacity ?? DEFAULT_LAYER_OPACITY, // configurable default opacity with fallback
         };
@@ -362,6 +367,11 @@ export const Layer = ({ layer }) => {
           shouldHaveOpacityControl: layer.shouldHaveOpacityControl ?? true,
           enforceNoColourSchemeSelector: layer.enforceNoColourSchemeSelector ?? false,
           enforceNoClassificationMethod: layer.enforceNoClassificationMethod ?? false,
+          fixLineWidth: layer.fixLineWidth ?? false,
+          fixedLineWidth:
+            typeof layer.fixedLineWidth === "number" && Number.isFinite(layer.fixedLineWidth)
+              ? layer.fixedLineWidth
+              : null,
           zoomToFeaturePlaceholderText: layer.zoomToFeaturePlaceholderText || "",
           defaultOpacity: layer.defaultOpacity ?? DEFAULT_LAYER_OPACITY,
           bufferSize: layer.bufferSize,

--- a/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.jsx
@@ -338,6 +338,8 @@ export const LayerControlEntry = memo(
     const enableZoomToFeature =
       layer.metadata?.enableZoomToFeature ?? Boolean(layer.metadata?.path);
     const layerConfigFromState = state?.layers?.[layer.id];
+    const isFixedLineWidth =
+      layer.type === "line" && layer.metadata?.fixLineWidth === true;
     const effectiveDefaultLineOffset =
       layerConfigFromState?.defaultLineOffset ??
       layer.metadata?.defaultLineOffset ??
@@ -375,7 +377,7 @@ export const LayerControlEntry = memo(
       Array.isArray(currentWidthFactor) &&
       currentWidthFactor[0] === "interpolate";
     const isNodeLayer = layer.type === "circle"; // station nodes are circle layers
-    const showWidth = isFeatureStateWidthExpression || isNodeLayer;
+    const showWidth = (isFeatureStateWidthExpression || isNodeLayer) && !isFixedLineWidth;
     const initialWidth = isFeatureStateWidthExpression
       ? calculateMaxWidthFactor(
           currentWidthFactor[currentWidthFactor.length - 1],

--- a/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.jsx
@@ -12,6 +12,8 @@ import { ColourSchemeDropdown, BandEditor, SelectorLabel } from "../Selectors";
 import { ClassificationDropdown } from "../Selectors/ClassificationDropdown";
 import { AppContext, PageContext } from "contexts";
 import { calculateMaxWidthFactor, applyWidthFactor, updateOpacityExpression } from "utils/map";
+import { useMapContext } from "hooks";
+import { actionTypes } from "reducers";
 
 /**
  * Styled container for the layer control entry.
@@ -194,6 +196,9 @@ export const LayerControlEntry = memo(
     handleCustomBandsChange,
     state,
   }) => {
+    const mapContext = useMapContext();
+    const dispatch = mapContext?.dispatch;
+
     const [visibility, setVisibility] = useState(
       layer.layout?.visibility || "visible"
     );
@@ -338,8 +343,16 @@ export const LayerControlEntry = memo(
     const enableZoomToFeature =
       layer.metadata?.enableZoomToFeature ?? Boolean(layer.metadata?.path);
     const layerConfigFromState = state?.layers?.[layer.id];
+    const isLineLayer = layer.type === "line";
     const isFixedLineWidth =
-      layer.type === "line" && layer.metadata?.fixLineWidth === true;
+      isLineLayer &&
+      (layerConfigFromState?.fixLineWidth ?? layer.metadata?.fixLineWidth) ===
+        true;
+    const fixedLineWidthFromState = layerConfigFromState?.fixedLineWidth;
+    const effectiveFixedLineWidth = Number.isFinite(fixedLineWidthFromState)
+      ? fixedLineWidthFromState
+      : 3;
+
     const effectiveDefaultLineOffset =
       layerConfigFromState?.defaultLineOffset ??
       layer.metadata?.defaultLineOffset ??
@@ -377,7 +390,8 @@ export const LayerControlEntry = memo(
       Array.isArray(currentWidthFactor) &&
       currentWidthFactor[0] === "interpolate";
     const isNodeLayer = layer.type === "circle"; // station nodes are circle layers
-    const showWidth = (isFeatureStateWidthExpression || isNodeLayer) && !isFixedLineWidth;
+    const showWidth =
+      (isFeatureStateWidthExpression || isNodeLayer) && !isFixedLineWidth;
     const initialWidth = isFeatureStateWidthExpression
       ? calculateMaxWidthFactor(
           currentWidthFactor[currentWidthFactor.length - 1],
@@ -398,6 +412,37 @@ export const LayerControlEntry = memo(
         : initialWidth || 1;
 
     const [widthFactor, setWidth] = useState(initialWidthForUI);
+
+    // Stores per-map original line-width paint so we can restore when toggling off.
+    const originalLineWidthByMapRef = useRef(new WeakMap());
+
+    const captureOriginalLineWidths = (map, ids) => {
+      if (!map) return;
+      const existing = originalLineWidthByMapRef.current.get(map) || {};
+      const next = { ...existing };
+      ids.forEach((id) => {
+        try {
+          next[id] = map.getPaintProperty(id, "line-width");
+        } catch {
+          // ignore
+        }
+      });
+      originalLineWidthByMapRef.current.set(map, next);
+    };
+
+    const restoreOriginalLineWidths = (map, ids) => {
+      if (!map) return;
+      const stored = originalLineWidthByMapRef.current.get(map);
+      if (!stored) return;
+      ids.forEach((id) => {
+        if (!(id in stored)) return;
+        try {
+          map.setPaintProperty(id, "line-width", stored[id]);
+        } catch {
+          // ignore
+        }
+      });
+    };
 
     const bandEditorData = useMemo(() => {
       if (
@@ -575,6 +620,52 @@ export const LayerControlEntry = memo(
       setWidth(nextFactor);
     };
 
+    const handleFixLineWidthToggle = (e) => {
+      const nextEnabled = Boolean(e.target.checked);
+
+      if (dispatch) {
+        dispatch({
+          type: actionTypes.UPDATE_LAYER_FIXED_LINE_WIDTH,
+          payload: {
+            layerName: layer.id,
+            fixLineWidth: nextEnabled,
+            fixedLineWidth: effectiveFixedLineWidth,
+          },
+        });
+      }
+
+      maps.forEach((map) => {
+        const ids = getLinkedLayerIds(map, layer.id);
+
+        if (nextEnabled) {
+          captureOriginalLineWidths(map, ids);
+          setPaintAcross(map, ids, "line-width", effectiveFixedLineWidth);
+        } else {
+          restoreOriginalLineWidths(map, ids);
+        }
+      });
+    };
+
+    const handleFixedLineWidthChange = (e) => {
+      const raw = parseFloat(e.target.value);
+      const nextWidth = Math.max(2, Math.min(12, Math.round(raw)));
+
+      if (dispatch) {
+        dispatch({
+          type: actionTypes.UPDATE_LAYER_FIXED_LINE_WIDTH,
+          payload: {
+            layerName: layer.id,
+            fixedLineWidth: nextWidth,
+          },
+        });
+      }
+
+      maps.forEach((map) => {
+        const ids = getLinkedLayerIds(map, layer.id);
+        setPaintAcross(map, ids, "line-width", nextWidth);
+      });
+    };
+
     const appliedNodeDefaultRef = useRef(false);
 
     useEffect(() => {
@@ -663,6 +754,47 @@ export const LayerControlEntry = memo(
             />
             <SliderValue>{(opacity * 100).toFixed(0)}%</SliderValue>
           </OpacityControl>
+        ),
+      });
+    }
+
+    if (isLineLayer) {
+      collapsibleSections.push({
+        key: "fixed-line-width",
+        node: (
+          <div>
+            <OpacityControl>
+              <input
+                id={`fix-line-width-${layer.id}`}
+                data-testid="checkbox fix line width"
+                type="checkbox"
+                checked={isFixedLineWidth}
+                onChange={handleFixLineWidthToggle}
+              />
+              <ControlLabel htmlFor={`fix-line-width-${layer.id}`}>
+                Fix line width
+              </ControlLabel>
+            </OpacityControl>
+
+            {isFixedLineWidth && (
+              <WidthControl>
+                <ControlLabel htmlFor={`fixed-width-${layer.id}`}>
+                  Fixed width
+                </ControlLabel>
+                <Slider
+                  id={`fixed-width-${layer.id}`}
+                  data-testid="slider fixed line width"
+                  type="range"
+                  min={2}
+                  max={12}
+                  step={1}
+                  value={effectiveFixedLineWidth}
+                  onChange={handleFixedLineWidthChange}
+                />
+                <SliderValue>{effectiveFixedLineWidth.toFixed(0)}</SliderValue>
+              </WidthControl>
+            )}
+          </div>
         ),
       });
     }

--- a/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.test.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.test.jsx
@@ -260,6 +260,47 @@ describe("LayerControlEntry component test", () => {
     });
     expect(screen.getByText("10.0")).toBeInTheDocument(); // rounded
   });
+
+  it("Does not render width factor slider when fixLineWidth is enabled", () => {
+    const mockGetLayer2 = jest.fn().mockReturnValue(true);
+    const mockGetPaintProperty2 = jest.fn().mockReturnValue(["interpolate", 100]);
+    const mockMap2 = {
+      getLayer: mockGetLayer2,
+      getPaintProperty: mockGetPaintProperty2,
+      setPaintProperty: jest.fn(),
+    };
+
+    const testProps = {
+      ...props,
+      maps: [mockMap2],
+      layer: {
+        id: "id",
+        type: "line",
+        layout: { visibility: false },
+        metadata: { path: "/", shouldHaveOpacityControl: true },
+      },
+      state: {
+        ...props.state,
+        layers: {
+          id: {
+            fixLineWidth: true,
+            fixedLineWidth: 3,
+          },
+        },
+      },
+    };
+
+    render(
+      <PageContext.Provider value={mockPageContext}>
+        <AppContext.Provider value={mockAppContexte}>
+          <LayerControlEntry {...testProps} />
+        </AppContext.Provider>
+      </PageContext.Provider>
+    );
+
+    expect(screen.queryByText("Width factor")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Width factor")).not.toBeInTheDocument();
+  });
   it("Test", () => {
     const mockMapContext = {
       state: {

--- a/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.test.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Accordion/LayerControlEntry.test.jsx
@@ -300,6 +300,12 @@ describe("LayerControlEntry component test", () => {
 
     expect(screen.queryByText("Width factor")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Width factor")).not.toBeInTheDocument();
+
+    // Fixed-width UI is shown for line layers.
+    expect(screen.getByText("Fix line width")).toBeInTheDocument();
+    expect(screen.getByTestId("checkbox fix line width")).toBeChecked();
+    expect(screen.getByText("Fixed width")).toBeInTheDocument();
+    expect(screen.getByTestId("slider fixed line width")).toBeInTheDocument();
   });
   it("Test", () => {
     const mockMapContext = {

--- a/packages/vis-core/src/reducers/mapReducer.js
+++ b/packages/vis-core/src/reducers/mapReducer.js
@@ -80,6 +80,7 @@ export const actionTypes = {
   UPDATE_CLASSIFICATION_METHOD: "UPDATE_CLASSIFICATION_METHOD",
   UPDATE_CUSTOM_BANDS: "UPDATE_CUSTOM_BANDS",
   UPDATE_LAYER_WIDTH_FACTOR: "UPDATE_LAYER_WIDTH_FACTOR",
+  UPDATE_LAYER_FIXED_LINE_WIDTH: "UPDATE_LAYER_FIXED_LINE_WIDTH",
   UPDATE_METADATA_FILTER: "UPDATE_METADATA_FILTER",
   SET_METADATA_TABLES: "SET_METADATA_TABLES",
   SET_METADATA_ERROR: "SET_METADATA_ERROR",
@@ -293,6 +294,29 @@ export const mapReducer = (state, action) => {
             ...state.layers[layerName],
             widthFactor,
           },
+        },
+      };
+    }
+
+    case actionTypes.UPDATE_LAYER_FIXED_LINE_WIDTH: {
+      const { layerName, fixLineWidth, fixedLineWidth } = action.payload;
+      const nextLayer = { ...state.layers[layerName] };
+
+      if (typeof fixLineWidth === "boolean") {
+        nextLayer.fixLineWidth = fixLineWidth;
+      }
+
+      if (fixedLineWidth === null) {
+        nextLayer.fixedLineWidth = null;
+      } else if (typeof fixedLineWidth === "number" && Number.isFinite(fixedLineWidth)) {
+        nextLayer.fixedLineWidth = fixedLineWidth;
+      }
+
+      return {
+        ...state,
+        layers: {
+          ...state.layers,
+          [layerName]: nextLayer,
         },
       };
     }

--- a/packages/vis-core/src/utils/map.js
+++ b/packages/vis-core/src/utils/map.js
@@ -235,6 +235,12 @@ export const updateOpacityExpression = (existingExpr, newOpacity) => {
  * @returns The paint property for the given geometries
  */
 export function createPaintProperty(bins, style, colours, opacityValue, layerConfig = {}) {
+  const shouldFixLineWidth = layerConfig?.fixLineWidth === true;
+  const fixedLineWidth =
+    typeof layerConfig?.fixedLineWidth === "number" &&
+    Number.isFinite(layerConfig.fixedLineWidth)
+      ? layerConfig.fixedLineWidth
+      : 3;
   let widthObject = [];
   let colors = [];
   let colorObject = [];
@@ -330,12 +336,14 @@ export function createPaintProperty(bins, style, colours, opacityValue, layerCon
           ["feature-state", "value"],
           ...colors,
         ],
-        "line-width": [
-          "interpolate",
-          ["linear"],
-          ["feature-state", "value"],
-          ...widthObject
-        ],
+        "line-width": shouldFixLineWidth
+          ? fixedLineWidth
+          : [
+              "interpolate",
+              ["linear"],
+              ["feature-state", "value"],
+              ...widthObject,
+            ],
         "line-opacity": [
           "case",
           ["in", ["feature-state", "value"], ["literal", [null]]],
@@ -360,21 +368,21 @@ export function createPaintProperty(bins, style, colours, opacityValue, layerCon
           colours[colours.length - 1], // Blue for positive values
           "rgba(0, 0, 0, 1)",
         ],
-        "line-width": [
-          "interpolate",
-          ["linear"],
-          ["feature-state", "valueAbs"],
-          ...widthObject
-        ],
+        "line-width": shouldFixLineWidth
+          ? fixedLineWidth
+          : [
+              "interpolate",
+              ["linear"],
+              ["feature-state", "valueAbs"],
+              ...widthObject,
+            ],
         "line-opacity": [
           "case",
           ["in", ["feature-state", "value"], ["literal", [null]]],
           0,
           opacityValue ?? 1,
         ],
-
-        "line-offset":
-          offsetExpression,
+        "line-offset": layerConfig.defaultLineOffset ?? offsetExpression,
 
       };
     case "line-categorical":
@@ -391,7 +399,7 @@ export function createPaintProperty(bins, style, colours, opacityValue, layerCon
           0,
           opacityValue ?? 1,
         ],
-        "line-width": 3,
+        "line-width": shouldFixLineWidth ? fixedLineWidth : 3,
         "line-offset": layerConfig.defaultLineOffset !== undefined ? [
           "interpolate",
           ["linear"],


### PR DESCRIPTION
This is a branch off #144 as this will require more development and that is a simple solution for the task required for CVT.

Functionality:
<ul>
  <li><strong>Line layers only:</strong> The new controls only render when <code>layer.type === "line"</code>.</li>

  <li><strong>New UI:</strong> Adds a <em>“Fix line width”</em> checkbox. If enabled, shows a <em>“Fixed width”</em> slider (range <strong>2–12</strong>, step <strong>1</strong>).</li>

  <li><strong>Default/initial state:</strong> Checkbox is checked if <code>state.layers[layer.id]?.fixLineWidth</code> is true, otherwise it falls back to <code>layer.metadata?.fixLineWidth</code> (config-driven).</li>

  <li><strong>What it turns off:</strong> When fixed width is enabled, the existing <em>“Width factor”</em> slider is hidden.</li>

  <li><strong>What it does to the map:</strong> When enabled, sets <code>line-width</code> to a constant number across the base layer and any linked layers (<code>-label</code>, <code>-spider</code>, <code>-spider-links</code>) on all maps.</li>

  <li><strong>Restore behavior:</strong> When disabled, restores the previous <code>line-width</code> paint values captured at enable-time (stored per map instance using a <code>WeakMap</code>).</li>

  <li><strong>Persistence:</strong> Uses a new reducer action <code>UPDATE_LAYER_FIXED_LINE_WIDTH</code> to persist <code>fixLineWidth</code> and <code>fixedLineWidth</code> into MapContext state (<code>state.layers[layerId]</code>).</li>

  <li><strong>Fixed width value:</strong> Uses <code>state.layers[layer.id]?.fixedLineWidth</code> if it’s a finite number; otherwise defaults to <strong>3</strong>.</li>

  <li><strong>Tests:</strong> Updated coverage to assert that when <code>fixLineWidth</code> is enabled the <em>Width factor</em> control is absent and the new checkbox + fixed-width slider are present.</li>
</ul>

<strong>Comments</strong>:
<ul>
<li> Do we want to make this render for all line layers, or only if <strong><em>fixLineWidth: true</em></strong> in page config?</li>

<li> I couldn't find one but do we have a styling for tickboxes? </li>

<li> Not sure if you want width factor rendered with this, but my thought process is if it is rendered and someones sliding width factors when this is ticked, I assume it will just break the app (I haven't tested).</li>

<li> The restore behaviour with the WeakMap I had a bit of help from copilot, I am not too sure exactly what we would want if it was turned on and then turned off, as technically the width factor slider would be re-rendered. It works well right now with when it is unticked on an vis that has fixLineWidth not defined, it just go back to what it was on initialisation where it has widthFactor restored etc. I think this is the best solution as otherwise I can see it causing breaks.</li>

</ul>