### PR TITLE
feat: support defaultClassification in visualisation config

### DIFF
--- a/packages/vis-core/src/Components/MapLayout/MapVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapVisualisation.jsx
@@ -126,16 +126,6 @@ export const MapVisualisation = ({
       : visualisationName;
   }, [visualisation?.type, visualisation?.joinLayer, visualisationName]);
 
-  const currentPage = useMemo(() => 
-    appContext.appPages.find((page) => page.url === window.location.pathname),
-    [appContext.appPages]
-  );
-
-  const visualisationConfig = useMemo(() =>
-    currentPage?.config?.visualisations?.find((v) => v.name === visualisationName),
-    [currentPage, visualisationName]
-  );
-
   // Retrieve classificationMethod per layer
   const classificationMethod =
     state.layers[layerKey]?.class_method ?? "d";
@@ -165,18 +155,18 @@ export const MapVisualisation = ({
   // Initialise classification method from visualisation config if not already set in state
   useEffect(() => {
     if (
-      visualisationConfig?.defaultClassification &&
+      visualisation?.defaultClassification &&
       !state.layers[layerKey]?.class_method
     ) {
       dispatch({
         type: "UPDATE_CLASSIFICATION_METHOD",
         payload: {
-          class_method: visualisationConfig.defaultClassification,
+          class_method: visualisation.defaultClassification,
           layerName: layerKey,
         },
       });
     }
-  }, [layerKey, visualisationConfig?.defaultClassification, state.layers, dispatch]);
+  }, [layerKey, visualisation?.defaultClassification, state.layers, dispatch]);
 
   // Reset fetch state when visualisation changes (page navigation)
   useEffect(() => {
@@ -320,13 +310,18 @@ export const MapVisualisation = ({
         return;
       }
 
+      // Reclassify data using combinedData
+      const currentPage = appContext.appPages.find(
+        (page) => page.url === window.location.pathname
+      );
+
       // Get trseLabel and customBands from state.layers
       const trseLabel =
         state.layers[layerKey]?.trseLabel === true;
       const customBands = state.layers[layerKey]?.customBands;
 
-      // Get defaultClassification from visualisationConfig
-      const defaultClassification = visualisationConfig?.defaultClassification;
+      // Get defaultClassification from visualisation
+      const defaultClassification = visualisation?.defaultClassification;
 
       const reclassifiedData = reclassifyData(
         combinedDataForClassification,
@@ -395,14 +390,12 @@ export const MapVisualisation = ({
       state.layers,
       resolvedStyle,
       appContext,
-      visualisation?.queryParams,
+      visualisation, 
       layerColorScheme,
       layerKey,
       // calculateColours,
       colorStyle,
       addFeaturesToMap,
-      currentPage,
-      visualisationConfig,
     ]
   );
 

--- a/packages/vis-core/src/Components/MapLayout/MapVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapVisualisation.jsx
@@ -126,6 +126,16 @@ export const MapVisualisation = ({
       : visualisationName;
   }, [visualisation?.type, visualisation?.joinLayer, visualisationName]);
 
+  const currentPage = useMemo(() => 
+    appContext.appPages.find((page) => page.url === window.location.pathname),
+    [appContext.appPages]
+  );
+
+  const visualisationConfig = useMemo(() =>
+    currentPage?.config?.visualisations?.find((v) => v.name === visualisationName),
+    [currentPage, visualisationName]
+  );
+
   // Retrieve classificationMethod per layer
   const classificationMethod =
     state.layers[layerKey]?.class_method ?? "d";
@@ -151,6 +161,22 @@ export const MapVisualisation = ({
     layerKey,
     shouldFilterDataToViewport,
   );
+
+  // Initialise classification method from visualisation config if not already set in state
+  useEffect(() => {
+    if (
+      visualisationConfig?.defaultClassification &&
+      !state.layers[layerKey]?.class_method
+    ) {
+      dispatch({
+        type: "UPDATE_CLASSIFICATION_METHOD",
+        payload: {
+          class_method: visualisationConfig.defaultClassification,
+          layerName: layerKey,
+        },
+      });
+    }
+  }, [layerKey, visualisationConfig?.defaultClassification, state.layers, dispatch]);
 
   // Reset fetch state when visualisation changes (page navigation)
   useEffect(() => {
@@ -294,15 +320,13 @@ export const MapVisualisation = ({
         return;
       }
 
-      // Reclassify data using combinedData
-      const currentPage = appContext.appPages.find(
-        (page) => page.url === window.location.pathname
-      );
-
       // Get trseLabel and customBands from state.layers
       const trseLabel =
         state.layers[layerKey]?.trseLabel === true;
       const customBands = state.layers[layerKey]?.customBands;
+
+      // Get defaultClassification from visualisationConfig
+      const defaultClassification = visualisationConfig?.defaultClassification;
 
       const reclassifiedData = reclassifyData(
         combinedDataForClassification,
@@ -311,7 +335,7 @@ export const MapVisualisation = ({
         appContext.defaultBands,
         currentPage,
         visualisation.queryParams,
-        { trseLabel, customBands } // Pass trseLabel and customBands in options
+        { trseLabel, customBands, defaultClassification } // Pass trseLabel, customBands and defaultClassification in options
       );
 
       // Get the metric definition for the current page/metric
@@ -377,6 +401,8 @@ export const MapVisualisation = ({
       // calculateColours,
       colorStyle,
       addFeaturesToMap,
+      currentPage,
+      visualisationConfig,
     ]
   );
 

--- a/packages/vis-core/src/utils/map.js
+++ b/packages/vis-core/src/utils/map.js
@@ -770,8 +770,8 @@ export const reclassifyData = (
       if (metric) {
         return normaliseContinuousBins(metric.values);
       }
-      // Fallback to quantile method if no metric definition is found
-      classificationMethod = "q";
+      // Fallback to page-level defaultClassification if specified, otherwise quantile
+      classificationMethod = options.defaultClassification ?? "q";
     }
     if (classificationMethod === "l") {
       values = values.map(replaceZeroValues);
@@ -840,8 +840,8 @@ export const reclassifyData = (
           ? metric.differenceValues
           : metric.differenceValues.slice(metric.differenceValues.length / 2);
       }
-      // Fallback to quantile method if no metric definition is found
-      classificationMethod = "q";
+      // Fallback to page-level defaultClassification if specified, otherwise quantile
+      classificationMethod = options.defaultClassification ?? "q";
     }
     if (classificationMethod === "l") {
       absValues = absValues.map(replaceZeroValues);
@@ -852,24 +852,24 @@ export const reclassifyData = (
     // Apply the appropriate classification method
     switch (classificationMethod) {
       case "j": // Jenks Natural Breaks
-        unroundedBins = jenksBreaks(absValues, 3);
+        unroundedBins = jenksBreaks(absValues, 6);
         break;
       
       case "s": // Standard Deviation
-        unroundedBins = standardDeviationBreaks(absValues, 3);
+        unroundedBins = standardDeviationBreaks(absValues, 6);
         break;
       
       case "h": // Head/Tail Breaks
         unroundedBins = headTailBreaks(absValues);
         // Limit to 3 classes for diverging
-        unroundedBins = unroundedBins.slice(0, Math.min(4, unroundedBins.length));
+        unroundedBins = unroundedBins.slice(0, Math.min(6, unroundedBins.length));
         break;
       
       case "q": // Quantile
       case "l": // Logarithmic
       case "k": // K-means
       default:
-        unroundedBins = [...new Set(chroma.limits(absValues, classificationMethod, 3))];
+        unroundedBins = [...new Set(chroma.limits(absValues, classificationMethod, 6))];
         break;
     }
 
@@ -878,6 +878,8 @@ export const reclassifyData = (
       roundedBins = roundedBins.map(replaceZeroPointValues);
     }
     roundedBins = roundedBins.filter((value) => value !== 0);
+    roundedBins = [...new Set(roundedBins)]; 
+    roundedBins = roundedBins.slice(0, 4);  
     if (style.includes("line")) return [0, ...roundedBins];
     const negativeBins = roundedBins.slice().reverse().map((val) => -val);
     return [...negativeBins, 0, ...roundedBins];


### PR DESCRIPTION
Added a `defaultClassification` property to the visualisation config, allowing pages to specify which classification method to use when no manual bands are defined. The value is a single letter aligned with existing method codes (e.g. `"j"` for Jenks Natural Breaks).

## Changes
- **`map.js`**: `reclassifyData` now reads `options.defaultClassification` as the fallback when `"d"` is selected but no metric definition exists in `bands.js`, for both continuous and diverging styles
- **`MapVisualisation.jsx`**: `currentPage` and `visualisationConfig` derived  at component level via `useMemo`; `defaultClassification` passed through to `reclassifyData` options; added initialisation effect to dispatch `UPDATE_CLASSIFICATION_METHOD` on mount when `defaultClassification` is set, so the dropdown reflects the correct method from the start
- **`map.js` (diverging)**: all classification methods now request 6 values and slice to the first 4 non-zero unique breaks, aiming for a consistent 4+0+4 = 9 band output. Note: this is not guaranteed as quantile on heavily skewed data may still return fewer unique breaks (e.g. 2 non-zero values → 5 bands total) due to data distribution.

## Usage
In the app's visualisation config:
```js
visualisations: [
  {
    name: "Map-based totals",
    defaultClassification: "j", // use Jenks when no manual bands defined
    ...
  }
]
```

- Closes https://github.com/Transport-for-the-North/Strategic-Analysis-Visualisation-Framework/issues/143
