### PR TITLE
ci: move app token generation to checkout step

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -47,10 +47,19 @@ jobs:
       packages: write
 
     steps:
+      # vis-core-release-bot generates GitHub App Token to bypass push restrictions later
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -68,14 +77,6 @@ jobs:
         run: |
           cd packages/vis-core
           npm run build
-
-      # vis-core-release-bot generates GitHub App Token to bypass push restrictions later
-      - name: Generate GitHub App Token
-        id: generate_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Run semantic-release
         run: npx semantic-release


### PR DESCRIPTION
Hopefully fixes rule bypass for semantic-release.