### PR TITLE
feat: implement metadata filtering client side based on API queries.

### DIFF
--- a/packages/vis-core/docs/Metadata Client Side Filtering.md
+++ b/packages/vis-core/docs/Metadata Client Side Filtering.md
@@ -71,12 +71,16 @@ Only the configured metadata table is filtered. Other metadata tables are left u
 
 ## Expected API Shape
 
-The current implementation assumes the endpoint returns a flat JSON array of values.
+The current implementation assumes the endpoint returns a flat JSON array of primitive values.
 
-Example response:
+Example responses:
 
 ```json
 [2, 3, 11, 15, 24, 30, 37, 45, 0]
+```
+
+```json
+["QGK_2042", "QGN_2042"]
 ```
 
 This is intentionally simple. The code does not try to support nested objects or alternative response shapes.
@@ -96,7 +100,7 @@ As a result, the existing visualisation pipeline can continue to use the same st
 visualisation.filteredScenarios
 ```
 
-This avoids adding custom scenario-filter plumbing to individual map or card components.
+This avoids adding custom metadata-filter plumbing to individual map or card components.
 
 ## Current NoRMS Usage
 
@@ -114,19 +118,19 @@ With this configuration, the full `input_norms_scenario` metadata table is inter
 
 This implementation assumes:
 
-- the scenario endpoint returns a flat array of primitive IDs
-- the relevant scenario metadata lives in one known metadata table
-- the ID column in that table is stable
+- the metadata-filter endpoint returns a flat array of primitive values
+- the relevant metadata lives in one known metadata table
+- the metadata column used for comparison is stable
 
-If another app uses a different metadata table name or ID column, only the config should need to change.
+If another app uses a different metadata table name or metadata column, only the config should need to change.
 
 If the endpoint response shape changes away from a flat array, `MapContext` will need to be updated.
 
 ## Summary
 
-This feature keeps scenario filtering at the client boundary:
+This feature keeps metadata filtering at the client boundary:
 
-- app config declares the app name and scenario-filter settings
+- app config declares the app name and metadata-filter settings
 - `MapContext` performs the intersection once
 - reducer state exposes the filtered rows to existing visualisation configs
 

--- a/packages/vis-core/docs/Metadata Client Side Filtering.md
+++ b/packages/vis-core/docs/Metadata Client Side Filtering.md
@@ -1,0 +1,133 @@
+# Metadata Filtering
+
+## Overview
+
+This document describes the client-side metadata-filtering flow introduced for apps that need to restrict the values available from a metadata table.
+
+The current use case is NoRMS, where the app should:
+
+- expose a runtime `visualiserAppName`
+- request the list of valid filter values for that app
+- intersect that list with the full metadata table
+- pass the filtered scenario rows down to the existing visualisation state
+
+## Runtime Flow
+
+### 1. App configuration resolves `visualiserAppName`
+
+Both app bootstraps now ensure that `visualiserAppName` is available in `AppContext`:
+
+- `src/App.jsx`
+- `packages/vis-core/src/Components/BaseApp/BaseApp.jsx`
+
+The runtime value is resolved as:
+
+1. `initialAppConfig.visualiserAppName`
+2. otherwise `null`
+
+This allows an app to explicitly set a value such as `Sandbox` without changing the folder name used by the app loader.
+
+If `visualiserAppName` is not provided, `AppContext.visualiserAppName` remains `null` and the client-side metadata-filtering request is skipped.
+
+### 2. App opts into metadata filtering
+
+Apps enable this behaviour by adding a `metadataFiltering` block to their app config.
+
+Example:
+
+```javascript
+export const appConfig = {
+  visualiserAppName: "Sandbox",
+  metadataFiltering: {
+    path: "/api/norms-app-scenario",
+    queryParamName: "appName",
+    metadataTableName: "input_norms_scenario",
+    metadataColumn: "id",
+  },
+};
+```
+
+Config fields:
+
+- `path`: endpoint that returns valid filter values
+- `queryParamName`: query-string parameter used to send the current app name
+- `metadataTableName`: metadata table to filter
+- `metadataColumn`: metadata-table column used for the intersection
+
+### 3. `MapContext` filters the metadata table
+
+`packages/vis-core/src/contexts/MapContext.jsx` performs the filtering during metadata-table initialisation.
+
+The flow is:
+
+1. Read `appContext.metadataFiltering`
+2. Call the configured endpoint with the current `appContext.visualiserAppName`
+3. Read the response as a flat array of valid filter values
+4. Convert the values into a `Set`
+5. Fetch each metadata table as normal
+6. When the configured metadata table is reached, filter its rows by the configured metadata column and value set
+
+Only the configured metadata table is filtered. Other metadata tables are left unchanged.
+
+## Expected API Shape
+
+The current implementation assumes the endpoint returns a flat JSON array of values.
+
+Example response:
+
+```json
+[2, 3, 11, 15, 24, 30, 37, 45, 0]
+```
+
+This is intentionally simple. The code does not try to support nested objects or alternative response shapes.
+
+## How Filtered Scenarios Reach Visualisations
+
+`packages/vis-core/src/reducers/mapReducer.js` stores the filtered rows in state and attaches them to visualisation configs.
+
+This happens in two places:
+
+- `SET_FILTERED_SCENARIOS` stores the rows and reapplies them to existing visualisations
+- `ADD_VISUALISATION` attaches the current `filteredScenarios` list to newly added visualisations
+
+As a result, the existing visualisation pipeline can continue to use the same state structure, while also receiving:
+
+```javascript
+visualisation.filteredScenarios
+```
+
+This avoids adding custom scenario-filter plumbing to individual map or card components.
+
+## Current NoRMS Usage
+
+The NoRMS app config currently uses:
+
+- `visualiserAppName: "Sandbox"`
+- `path: "/api/norms-app-scenario"`
+- `queryParamName: "appName"`
+- `metadataTableName: "input_norms_scenario"`
+- `metadataColumn: "id"`
+
+With this configuration, the full `input_norms_scenario` metadata table is intersected with the values returned for `Sandbox`.
+
+## Assumptions
+
+This implementation assumes:
+
+- the scenario endpoint returns a flat array of primitive IDs
+- the relevant scenario metadata lives in one known metadata table
+- the ID column in that table is stable
+
+If another app uses a different metadata table name or ID column, only the config should need to change.
+
+If the endpoint response shape changes away from a flat array, `MapContext` will need to be updated.
+
+## Summary
+
+This feature keeps scenario filtering at the client boundary:
+
+- app config declares the app name and scenario-filter settings
+- `MapContext` performs the intersection once
+- reducer state exposes the filtered rows to existing visualisation configs
+
+That keeps the behaviour centralised and avoids special-case logic in individual components.

--- a/packages/vis-core/src/Components/BaseApp/BaseApp.jsx
+++ b/packages/vis-core/src/Components/BaseApp/BaseApp.jsx
@@ -103,11 +103,11 @@ export function BaseApp({
 
         const apiSchema = await api.metadataService.getSwaggerFile();
         const authenticationRequired = initialAppConfig.authenticationRequired ?? true;
-        const resolvedAppName = initialAppConfig.visualiserAppName ?? null;
+        const visualiserAppName = initialAppConfig.visualiserAppName ?? null;
 
         setAppConfig({
           ...initialAppConfig,
-          visualiserAppName: resolvedAppName,
+          visualiserAppName: visualiserAppName,
           apiSchema: apiSchema,
           defaultBands: bands,
           authenticationRequired: authenticationRequired

--- a/packages/vis-core/src/Components/BaseApp/BaseApp.jsx
+++ b/packages/vis-core/src/Components/BaseApp/BaseApp.jsx
@@ -103,9 +103,11 @@ export function BaseApp({
 
         const apiSchema = await api.metadataService.getSwaggerFile();
         const authenticationRequired = initialAppConfig.authenticationRequired ?? true;
+        const resolvedAppName = initialAppConfig.visualiserAppName ?? null;
 
         setAppConfig({
           ...initialAppConfig,
+          visualiserAppName: resolvedAppName,
           apiSchema: apiSchema,
           defaultBands: bands,
           authenticationRequired: authenticationRequired

--- a/packages/vis-core/src/contexts/MapContext.jsx
+++ b/packages/vis-core/src/contexts/MapContext.jsx
@@ -38,6 +38,26 @@ const isDuplicateValue = (values, value) => {
   );
 };
 
+const normaliseMetadataFilterValue = (value) => {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  return String(value);
+};
+
+const extractMetadataFilterValuesFromResponse = (response) => {
+  if (!Array.isArray(response)) {
+    return null;
+  }
+
+  return new Set(
+    response
+      .map((filterValue) => normaliseMetadataFilterValue(filterValue))
+      .filter((filterValue) => filterValue !== null)
+  );
+};
+
 /**
  * MapProvider component to manage map-related state and context.
  * @function MapProvider
@@ -68,6 +88,7 @@ export const MapProvider = ({ children }) => {
     metadataTables: {},
     metadataFilters: [],
     filters: [],
+    filteredScenarios: [],
     map: null,
     isMapReady: false,
     isLoading: true,
@@ -102,6 +123,25 @@ export const MapProvider = ({ children }) => {
     const fetchMetadataTables = async () => {
       const metadataTables = {};
       const emptyTables = [];
+      let filteredScenarios = [];
+
+      const metadataFiltering = appContext.metadataFiltering;
+      let validMetadataFilterValues = null;
+
+      if (metadataFiltering?.path && appContext?.visualiserAppName) {
+        try {
+          const queryParamName = metadataFiltering.queryParamName ?? "appName";
+          const metadataFilterResponse = await api.baseService.get(metadataFiltering.path, {
+            queryParams: {
+              [queryParamName]: appContext.visualiserAppName,
+            },
+          });
+
+          validMetadataFilterValues = extractMetadataFilterValuesFromResponse(metadataFilterResponse);
+        } catch (error) {
+          console.error("Failed to fetch valid metadata filter values:", error);
+        }
+      }
       
       for (const table of pageContext.config.metadataTables) {
         try {
@@ -118,6 +158,24 @@ export const MapProvider = ({ children }) => {
             }
           }
 
+          const metadataFilterTableName = metadataFiltering?.metadataTableName;
+          const metadataFilterColumn = metadataFiltering?.metadataColumn ?? "id";
+          const isMetadataFilterTable = metadataFilterTableName && table.name === metadataFilterTableName;
+
+          if (
+            isMetadataFilterTable &&
+            validMetadataFilterValues instanceof Set &&
+            Array.isArray(filteredData)
+          ) {
+            filteredData = filteredData.filter((row) =>
+              validMetadataFilterValues.has(normaliseMetadataFilterValue(row?.[metadataFilterColumn]))
+            );
+          }
+
+          if (isMetadataFilterTable && Array.isArray(filteredData)) {
+            filteredScenarios = filteredData;
+          }
+
           metadataTables[table.name] = filteredData;
           
           // Check if table is empty
@@ -130,7 +188,7 @@ export const MapProvider = ({ children }) => {
         }
       }
 
-      return { metadataTables, emptyTables };
+      return { metadataTables, emptyTables, filteredScenarios };
     };
 
     /**
@@ -371,7 +429,7 @@ export const MapProvider = ({ children }) => {
       });
 
       // Initialise filters
-      const { metadataTables, emptyTables } = await fetchMetadataTables();
+      const { metadataTables, emptyTables, filteredScenarios } = await fetchMetadataTables();
       
       // Check if any required metadata tables are empty
       if (emptyTables.length > 0) {
@@ -403,6 +461,7 @@ export const MapProvider = ({ children }) => {
       }
       
       dispatch({ type: actionTypes.SET_METADATA_TABLES, payload: metadataTables });
+      dispatch({ type: actionTypes.SET_FILTERED_SCENARIOS, payload: filteredScenarios });
       await initializeFilters(metadataTables);
 
       dispatch({ type: actionTypes.SET_LOADING_FINISHED });

--- a/packages/vis-core/src/contexts/MapContext.test.jsx
+++ b/packages/vis-core/src/contexts/MapContext.test.jsx
@@ -50,6 +50,7 @@ jest.mock("defaults", () => ({
 import React from "react";
 import { AppContext, FilterContext, MapProvider, PageContext } from "contexts";
 import { api } from "services";
+import { actionTypes } from "reducers";
 import {
   hasRouteParameterOrQuery,
   processParameters,
@@ -181,7 +182,13 @@ beforeEach(() => {
   // Re-initialize mock implementations after clearAllMocks
   mockGet.mockResolvedValue([{ id: 1 }]);
   mockUseReducer.mockReturnValue([
-    {pageIsReady: true},
+    {
+      pageIsReady: true,
+      filters: [],
+      visualisations: {},
+      leftVisualisations: {},
+      rightVisualisations: {},
+    },
     jest.fn(),
   ]);
   mockProcessParameters.mockReturnValue({
@@ -216,7 +223,16 @@ describe("MapProvider component tests", () => {
 
 describe("parameterisedLayers for each layer", () => {
   beforeEach(() => {
-    mockUseReducer.mockReturnValue([{}, mockDispatch]);
+    mockUseReducer.mockReturnValue([
+      {
+        pageIsReady: false,
+        filters: [],
+        visualisations: {},
+        leftVisualisations: {},
+        rightVisualisations: {},
+      },
+      mockDispatch,
+    ]);
 
     mockProcessParameters.mockReturnValue({
       params: "params",
@@ -239,5 +255,70 @@ describe("parameterisedLayers for each layer", () => {
     );
 
     expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it("filters metadata rows using valid filter values and propagates filtered scenarios", async () => {
+    const scenarioRows = [
+      { id: 1, vis_description: "Scenario 1" },
+      { id: 2, vis_description: "Scenario 2" },
+      { id: 3, vis_description: "Scenario 3" },
+    ];
+
+    mockUseReducer.mockReturnValue([
+      {
+        pageIsReady: false,
+        filters: [],
+        visualisations: {
+          testVisualisation: { name: "testVisualisation" },
+        },
+        leftVisualisations: {
+          testVisualisation: { name: "testVisualisation" },
+        },
+        rightVisualisations: {
+          testVisualisation: { name: "testVisualisation" },
+        },
+      },
+      mockDispatch,
+    ]);
+
+    mockGet
+      .mockResolvedValueOnce([1, 3])
+      .mockResolvedValueOnce(scenarioRows);
+
+    const appContextWithMetadataFiltering = {
+      ...mockAppContexte,
+      visualiserAppName: "Sandbox",
+      metadataFiltering: {
+        path: "/api/norms-app-scenario",
+        queryParamName: "appName",
+        metadataTableName: "metadataTableName",
+        metadataColumn: "id",
+      },
+    };
+
+    render(
+      <PageContext.Provider value={mockPageContext}>
+        <AppContext.Provider value={appContextWithMetadataFiltering}>
+          <FilterContext.Provider value={mockFilterContext}>
+            <MapProvider>
+              <p>ImAChildren</p>
+            </MapProvider>
+          </FilterContext.Provider>
+        </AppContext.Provider>
+      </PageContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith("/api/norms-app-scenario", {
+        queryParams: { appName: "Sandbox" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: actionTypes.SET_FILTERED_SCENARIOS,
+        payload: [scenarioRows[0], scenarioRows[2]],
+      });
+    });
   });
 });

--- a/packages/vis-core/src/contexts/MapContext.test.jsx
+++ b/packages/vis-core/src/contexts/MapContext.test.jsx
@@ -321,4 +321,63 @@ describe("parameterisedLayers for each layer", () => {
       });
     });
   });
+
+  it("filters metadata rows when the endpoint returns string values", async () => {
+    const scenarioRows = [
+      { scenario_code: "QGK_2042", vis_description: "Scenario 1" },
+      { scenario_code: "QGM_2042", vis_description: "Scenario 2" },
+      { scenario_code: "QGN_2042", vis_description: "Scenario 3" },
+    ];
+
+    mockUseReducer.mockReturnValue([
+      {
+        pageIsReady: false,
+        filters: [],
+        visualisations: {
+          testVisualisation: { name: "testVisualisation" },
+        },
+        leftVisualisations: {
+          testVisualisation: { name: "testVisualisation" },
+        },
+        rightVisualisations: {
+          testVisualisation: { name: "testVisualisation" },
+        },
+      },
+      mockDispatch,
+    ]);
+
+    mockGet
+      .mockResolvedValueOnce(["QGK_2042", "QGN_2042"])
+      .mockResolvedValueOnce(scenarioRows);
+
+    const appContextWithMetadataFiltering = {
+      ...mockAppContexte,
+      visualiserAppName: "Sandbox",
+      metadataFiltering: {
+        path: "/api/norms-app-scenario",
+        queryParamName: "appName",
+        metadataTableName: "metadataTableName",
+        metadataColumn: "scenario_code",
+      },
+    };
+
+    render(
+      <PageContext.Provider value={mockPageContext}>
+        <AppContext.Provider value={appContextWithMetadataFiltering}>
+          <FilterContext.Provider value={mockFilterContext}>
+            <MapProvider>
+              <p>ImAChildren</p>
+            </MapProvider>
+          </FilterContext.Provider>
+        </AppContext.Provider>
+      </PageContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: actionTypes.SET_FILTERED_SCENARIOS,
+        payload: [scenarioRows[0], scenarioRows[2]],
+      });
+    });
+  });
 });

--- a/packages/vis-core/src/reducers/mapReducer.js
+++ b/packages/vis-core/src/reducers/mapReducer.js
@@ -15,6 +15,18 @@ const findFirstColourValue = (filters) => {
   return null;
 };
 
+const attachFilteredScenarios = (visualisations = {}, filteredScenarios = []) => {
+  return Object.fromEntries(
+    Object.entries(visualisations).map(([name, visualisation]) => [
+      name,
+      {
+        ...visualisation,
+        filteredScenarios,
+      },
+    ])
+  );
+};
+
 /**
  * Updates a params map (queryParams or pathParams) across a set of visualisations.
  *
@@ -84,6 +96,7 @@ export const actionTypes = {
   SET_METADATA_TABLES: "SET_METADATA_TABLES",
   SET_METADATA_ERROR: "SET_METADATA_ERROR",
   SET_FILTERS: "SET_FILTERS",
+  SET_FILTERED_SCENARIOS: "SET_FILTERED_SCENARIOS",
   RESET_CONTEXT: "RESET_CONTEXT",
   UPDATE_FILTER_VALUES: "UPDATE_FILTER_VALUES",
   SET_SELECTION_MODE: "SET_SELECTION_MODE",
@@ -158,6 +171,7 @@ export const mapReducer = (state, action) => {
         filters: {},
         leftVisualisations: {},
         rightVisualisations: {},
+        filteredScenarios: [],
         isLoading: true,
         pageIsReady: false,
         selectionMode: null,
@@ -299,10 +313,13 @@ export const mapReducer = (state, action) => {
 
     case actionTypes.ADD_VISUALISATION: {
       // Logic to add a visualisation
-      const visualisationContent = {
-        ...state.visualisations,
-        ...action.payload,
-      };
+      const visualisationContent = attachFilteredScenarios(
+        {
+          ...state.visualisations,
+          ...action.payload,
+        },
+        state.filteredScenarios
+      );
       return {
         ...state,
         visualisations: visualisationContent,
@@ -576,6 +593,15 @@ export const mapReducer = (state, action) => {
     }
     case actionTypes.SET_FILTERS: {
       return { ...state, filters: action.payload };
+    }
+    case actionTypes.SET_FILTERED_SCENARIOS: {
+      return {
+        ...state,
+        filteredScenarios: action.payload,
+        visualisations: attachFilteredScenarios(state.visualisations, action.payload),
+        leftVisualisations: attachFilteredScenarios(state.leftVisualisations, action.payload),
+        rightVisualisations: attachFilteredScenarios(state.rightVisualisations, action.payload),
+      };
     }
     case actionTypes.UPDATE_FILTER_VALUES: {
       return { ...state, filters: action.payload.updatedFilters };


### PR DESCRIPTION
Documentation included, `visualiserAppName` is added to appConfig as well as `metadataFiltering` to allow the application to query a API path to retrieve an array of values which then filter down a metadata table by using `metadataTableName` and `metadataColumn` mappings, therefore any metadata table can be filtered down in future.

e.g. `export const appConfig = {
  visualiserAppName: "Sandbox",
  metadataFiltering: {
    path: "/api/norms-app-scenario",
    queryParamName: "appName",
    metadataTableName: "input_norms_scenario",
    metadataColumn: "id",
  },
};`

To be worked with branch: `31-metadata-client-filters-app` in NoRMS app for testing.

Have tested this and works, SMU does not show as that does not have an app registration as it seems to be a new addition to table so that made it easier. Also tested by using the maintenance script to change TET etc to is_deleted=True and this therefore does not add that selection to the filter list.

Test suites run all successful.