### PR TITLE
feat: add error overlay where filters are empty. remove clearing of error context in useFetchVisualisationData.

### DIFF
--- a/packages/vis-core/src/contexts/FilterContext.jsx
+++ b/packages/vis-core/src/contexts/FilterContext.jsx
@@ -10,6 +10,14 @@ export const FilterContext = createContext();
 
 const initialFilterState = {};
 
+// Multi-select filters often emit a new array instance with the same contents.
+// Compare by value so the reducer can ignore no-op updates.
+const areArraysEqual = (left, right) => {
+  if (!Array.isArray(left) || !Array.isArray(right)) return false;
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+};
+
 // Define action types
 const filterActionTypes = {
   SET_FILTER_VALUE: 'SET_FILTER_VALUE',
@@ -31,7 +39,17 @@ const filterReducer = (state, action) => {
       // Prevent null/undefined from being written into state
       if (value == null) {
         const isArray = Array.isArray(state[filterId]);
-        return { ...state, [filterId]: isArray ? [] : null };
+        const emptyValue = isArray ? [] : null;
+
+        // Repeated "clear" actions should not create fresh state objects.
+        if (
+          (emptyValue === null && state[filterId] == null) ||
+          (Array.isArray(emptyValue) && areArraysEqual(state[filterId], emptyValue))
+        ) {
+          return state;
+        }
+
+        return { ...state, [filterId]: emptyValue };
       }
 
       // Safe numeric coercion: avoid '' -> 0 and other isNaN quirks
@@ -56,7 +74,11 @@ const filterReducer = (state, action) => {
           : value;
 
       // Check if the value has actually changed
-      if (state[filterId] === parsedValue) {
+      if (
+        state[filterId] === parsedValue ||
+        // Arrays need value-based comparison because reference equality is too strict here.
+        (Array.isArray(state[filterId]) && Array.isArray(parsedValue) && areArraysEqual(state[filterId], parsedValue))
+      ) {
         return state; // No change in state
       }
 

--- a/packages/vis-core/src/contexts/MapContext.jsx
+++ b/packages/vis-core/src/contexts/MapContext.jsx
@@ -18,7 +18,8 @@ import {
   getInitialFilterValue
 } from "utils";
 import { defaultMapStyle, defaultMapZoom, defaultMapCentre } from "defaults";
-import { AppContext, PageContext, FilterContext, ErrorContext } from "contexts";
+import { AppContext, PageContext, FilterContext } from "contexts";
+import { ErrorContext } from "./ErrorContext";
 import { api } from "services";
 
 // Create a context for the app configuration
@@ -50,7 +51,6 @@ export const MapProvider = ({ children }) => {
   const { dispatch: filterDispatch } = useContext(FilterContext);
   const errorContext = useContext(ErrorContext);
   const errorDispatch = errorContext?.dispatch ?? (() => {}); // no-op if provider missing
-  const errorState = errorContext?.state ?? null;
 
   // Initialize state within the provider function
   const initialState = {
@@ -142,6 +142,7 @@ export const MapProvider = ({ children }) => {
       const filters = [];
       const filterState = {};
       const paramNameToUuidMap = {};
+      const emptyMetadataFilters = [];
       const usedFilterIds = new Set();
 
       for (const filter of pageContext.config.filters) {
@@ -237,6 +238,15 @@ export const MapProvider = ({ children }) => {
                   }
 
                   filterWithId.values.values = uniqueValues;
+
+                  if (uniqueValues.length === 0) {
+                    emptyMetadataFilters.push({
+                      filterName: filterWithId.filterName,
+                      paramName: filterWithId.paramName,
+                      metadataTableName: filterWithId.values.metadataTableName,
+                    });
+                  }
+
                   filters.push(filterWithId);
                 } else {
                   console.error(`Metadata table ${filterWithId.values.metadataTableName} not found or empty`);
@@ -266,6 +276,44 @@ export const MapProvider = ({ children }) => {
         }
         return filter;
       });
+
+      if (emptyMetadataFilters.length > 0) {
+        console.warn('[MapContext] empty metadata filters detected', {
+          pageName: pageContext.pageName,
+          emptyMetadataFilters,
+          filterStateKeys: Object.keys(filterState),
+        });
+        console.log('[MapContext] ErrorContext availability before SET_ERROR', {
+          hasErrorContext: !!errorContext,
+          hasErrorDispatch: typeof errorContext?.dispatch === 'function',
+        });
+
+        const technicalDetails = emptyMetadataFilters
+          .map(
+            ({ filterName, paramName, metadataTableName }) =>
+              `Filter: ${filterName || paramName}\nParameter: ${paramName}\nMetadata table: ${metadataTableName}`
+          )
+          .join('\n\n');
+
+        errorDispatch({
+          type: errorActionTypes.SET_ERROR,
+          payload: {
+            title: 'No Filter Values Available',
+            subtitle: 'A metadata filter returned no values',
+            message:
+              emptyMetadataFilters.length === 1
+                ? `The filter "${emptyMetadataFilters[0].filterName || emptyMetadataFilters[0].paramName}" has no available values from the API for the current metadata query.`
+                : 'One or more filters have no available values from the API for the current metadata query.',
+            supportMessage: 'Please contact support if the issue persists.',
+            supportDetails: 'The filters listed below were built from metadata, but the filtered API result returned no options.',
+            technicalDetails,
+          },
+        });
+
+        console.warn('[MapContext] continuing initialization so the page can render behind the error overlay', {
+          pageName: pageContext.pageName,
+        });
+      }
 
       dispatch({ type: actionTypes.SET_FILTERS, payload: updatedFilters });
       filterDispatch({ type: 'INITIALIZE_FILTERS', payload: filterState });
@@ -375,6 +423,11 @@ export const MapProvider = ({ children }) => {
       
       // Check if any required metadata tables are empty
       if (emptyTables.length > 0) {
+        console.warn('[MapContext] aborting due to empty metadata tables', {
+          pageName: pageContext.pageName,
+          emptyTables,
+        });
+
         const message =
           emptyTables.length === 1
             ? `The metadata table is empty or contains no valid data. This page requires valid metadata to function properly.`

--- a/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
+++ b/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
@@ -3,8 +3,6 @@ import { debounce } from 'lodash';
 import { api } from 'services';
 
 import { DataFetchState } from 'enums';
-import { ErrorContext } from 'contexts';
-import { errorActionTypes } from 'reducers';
 
 // --- NEW HELPER FUNCTIONS FOR SPATIAL MATHS ---
 
@@ -185,11 +183,6 @@ export const useFetchVisualisationData = (
   const prevParamsRef = useRef();
   const prevVisualisationNameRef = useRef();
   
-  // Access ErrorContext to display an overlay for missing parameters (if provider present)
-  const errorContext = useContext(ErrorContext);
-  const errorDispatch = errorContext?.dispatch ?? (() => {}); // no-op if provider missing
-  const errorState = errorContext?.state ?? null;
-
   /**
    * - React StrictMode (dev) mounts/unmounts quickly; a 400ms debounced call can be cancelled
    *   before it fires, so params signature would still be consumed.
@@ -486,11 +479,6 @@ export const useFetchVisualisationData = (
       return;
     }
 
-    // Clear any previously shown param-missing overlay.
-    if (errorDispatch) {
-      errorDispatch({ type: errorActionTypes.CLEAR_ERROR });
-    }
-
     // Track a combined signature of both param maps to detect changes.
     const currentParamsStr = JSON.stringify({ queryParams, pathParams });
 
@@ -517,7 +505,6 @@ export const useFetchVisualisationData = (
     visualisation?.queryParams,
     visualisation?.pathParams,
     fetchDataForVisualisation,
-    errorDispatch,
   ]);
 
   // When server-side viewport filtering is enabled, re-fetch data when the map viewport changes.


### PR DESCRIPTION
Requires `ErrorProvider` to be initialised in `App.jsx` if not using `BaseApp`. 

NoRMS currently does not have this. Are we planning to get all apps to use `BaseApp` as this would be the perfect scenario @brereh @NicholasAJackson7.