### PR TITLE
fix: prevent undefined prefix on burger button image src

### DIFF
--- a/packages/vis-core/src/Components/Navbar/Button.jsx
+++ b/packages/vis-core/src/Components/Navbar/Button.jsx
@@ -18,7 +18,7 @@ export function Button({ className, src, alt, onClick }) {
   return (
     <div className={`Button ${className || ""}`} onClick={handleClick} data-testid="custom-button">
       <img
-        src={`${import.meta.env.VITE_PUBLIC_URL}${src}`}
+        src={`${import.meta.env.VITE_PUBLIC_URL || ""}${src}`}
         alt={alt}
       />
     </div>


### PR DESCRIPTION
## Fix: Burger button not visible on mobile/narrow screens

### Problem
The mobile navigation burger button was invisible on narrow viewports. The `Button` component in the `Navbar` constructs the image `src` using `VITE_PUBLIC_URL`:

```jsx
src={`${import.meta.env.VITE_PUBLIC_URL}${src}`}
```

Think this is legacy setup from the previous CRA monorepo setup? To be safe, rather than remove it, add a fallback for when not provided? (Which I think is all apps running vis-core?)

### Fix
Added a `|| ""` fallback so the prefix safely becomes an empty string when the env var is not set:

```jsx
src={`${import.meta.env.VITE_PUBLIC_URL || ""}${src}`}
```

### Files changed
- `src/Components/Navbar/Button.jsx`