### PR TITLE
feat: apply formatNumber to legend band labels

### DIFF
--- a/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.jsx
+++ b/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.jsx
@@ -5,6 +5,7 @@ import { convertStringToNumber, numberWithCommas } from "utils";
 import { useMapContext, useFetchVisualisationData } from "hooks";
 import { PageContext, useAppContext } from "contexts";
 import { createPortal } from 'react-dom';
+import { formatNumber } from "utils";
 
 /**
  * useIsMobile
@@ -442,7 +443,7 @@ const isRenderableEntry = (e) => {
 
 const formatLegendLabelValue = (value) => {
   const numericValue = convertStringToNumber(value);
-  return Number.isFinite(numericValue) ? numberWithCommas(numericValue) : value;
+  return Number.isFinite(numericValue) ? formatNumber(numericValue) : value;
 };
 
 /**


### PR DESCRIPTION
## Summary
Applies consistent number formatting to legend band labels by updating formatLegendLabelValue in DynamicLegend to use formatNumber instead of numberWithCommas.

## Changes
- Updated formatLegendLabelValue in DynamicLegend.jsx to use formatNumber

## Formatting Rules Applied
- Very small decimals (< 0.01): 2 significant figures (e.g. 0.0031)
- Values up to 999: 2 decimal places (e.g. 854.25)
- Values 1,000 to 9,999: 0 decimal places (e.g. 1235)
- Values 10,000+: K/M/B suffix with 2 decimal places (e.g. 12.35K, 1.23M, 4.50B)

## Screenshots
<img width="1898" height="919" alt="image" src="https://github.com/user-attachments/assets/23e7eb7f-f685-4d98-bad2-bd371d90daf6" />
<img width="1909" height="918" alt="image" src="https://github.com/user-attachments/assets/8108915b-500e-4830-bc96-161ed88b9e6c" />


Closes #190 




