### PR TITLE
fix: allow single selection to feed through to filterState.

### DIFF
--- a/packages/vis-core/src/Components/Sidebar/Selectors/Toggle.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Selectors/Toggle.jsx
@@ -142,7 +142,11 @@ export const Toggle = ({ filter, onChange, bgColor }) => {
 
     if (!filter.multiSelect) {
       const currentlyHidden = options.find((o) => o.paramValue === current)?.isHidden;
-      if (currentlyHidden) {
+      const shouldAutoSelectOnlyVisible = current == null && visibleOptions.length === 1;
+
+      // Commit the only visible value when nothing has been written yet, and
+      // also recover if the current value becomes hidden after validation.
+      if (currentlyHidden || shouldAutoSelectOnlyVisible) {
         const fallback = visibleOptions[0]?.paramValue ?? null;
         onChange(filter, fallback);
         setSelectedButtons(fallback);

--- a/packages/vis-core/src/Components/Sidebar/Selectors/Toggle.test.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Selectors/Toggle.test.jsx
@@ -56,6 +56,34 @@ let props = {
   onChange: jest.fn(),
 };
 describe("Toggle component tests", () => {
+  beforeEach(() => {
+    props = {
+      filter: {
+        values: {
+          values: [
+            {
+              paramValue: "paramValue",
+              displayValue: "displayValue",
+              isValid: true,
+            },
+            {
+              paramValue: "paramValue1",
+              displayValue: "displayValue1",
+              isValid: true,
+            },
+            {
+              paramValue: "paramValue2",
+              displayValue: "displayValue2",
+              isValid: true,
+            },
+          ],
+        },
+        multiSelect: true,
+      },
+      onChange: jest.fn(),
+    };
+  });
+
   it("Click on the displayValue button with multiselect", async () => {
     render(
       <FilterContext.Provider value={mockFilterContext}>
@@ -208,6 +236,42 @@ describe("Toggle component tests", () => {
         multiSelect: false,
       },
       "paramValue" // Because it's not a multiselect button
+    );
+  });
+
+  it("auto-selects the only visible option for single-select toggles", () => {
+    const singleOptionProps = {
+      filter: {
+        id: "single-visible-toggle",
+        values: {
+          values: [
+            {
+              paramValue: "only-option",
+              displayValue: "Only Option",
+              isValid: true,
+            },
+            {
+              paramValue: "hidden-option",
+              displayValue: "Hidden Option",
+              isValid: true,
+              isHidden: true,
+            },
+          ],
+        },
+        multiSelect: false,
+      },
+      onChange: jest.fn(),
+    };
+
+    render(
+      <FilterContext.Provider value={{ ...mockFilterContext, state: {} }}>
+        <Toggle {...singleOptionProps} />
+      </FilterContext.Provider>
+    );
+
+    expect(singleOptionProps.onChange).toHaveBeenCalledWith(
+      singleOptionProps.filter,
+      "only-option"
     );
   });
 });


### PR DESCRIPTION
Change simply allows toggle with only one value to be sent through to `filterState` as it is locally initialised (hence why it is coloured as selected) but this is not triggered and dispatched to `filterState` on initialisation.

Tests added all successful and also working with more than 1 selections on toggle pages.