### PR TITLE
Custom Banding Fixes

### DIFF
--- a/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.jsx
+++ b/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.jsx
@@ -744,6 +744,7 @@ export const DynamicLegend = ({ map }) => {
                 color: stop.color,
                 width: getEntryWidth(widthStop, isMobile, layer, paintProps, rawLabel),
                 label,
+                rawValue: Number(stop.value),
                 type: layer.type,
                 isDashed: getEntryDashStatus(dashStop, paintProps, rawLabel),
               });
@@ -789,9 +790,10 @@ export const DynamicLegend = ({ map }) => {
             return null;
           }
 
-          // Parse legend entry labels, remove commas, convert to float
+          // Use raw numeric stop values for band-edge comparisons.
+          // Parsing formatted labels (e.g. "10.00K") yields incorrect numbers.
           const legendNumericEntries = filteredEntries
-            .map(e => parseFloat(String(e.label).replace(/,/g, '')))
+            .map(e => (e.rawValue !== undefined && !isNaN(e.rawValue) ? e.rawValue : parseFloat(String(e.label).replace(/,/g, ''))))
             .filter(v => !isNaN(v));
           
           return {
@@ -843,7 +845,6 @@ export const DynamicLegend = ({ map }) => {
   }, [legendItems, isMobile]);
   
   // If there are no legend items, render nothing.
-  
   if (legendItems.length === 0) {
     return null;
   }
@@ -854,44 +855,41 @@ export const DynamicLegend = ({ map }) => {
         // Out-of-band check: only for continuous/diverging bands
         let outOfBand = false;
         let minBand = null, maxBand = null;
-        let bandsManuallySet = false;
         
         const classMethod = state.layers?.[item.layerId]?.class_method;
+        // Only show this warning when the user has explicitly saved custom bands.
+        const layerHasCustomBands =
+          Array.isArray(state.layers?.[item.layerId]?.customBands) &&
+          state.layers[item.layerId].customBands.length > 0;
 
-        // Only show this warning for explicit custom banding.
-        if (classMethod === 'c' && item.legendEntriesNumeric && Array.isArray(item.legendEntriesNumeric) && item.legendEntriesNumeric.length > 1) {
-          // Use actual band values from item.visualisation.bands for min/max
-          const bandEdges = item.legendEntriesNumeric.filter(v => !isNaN(v));
-          minBand = Math.min(...bandEdges);
-          maxBand = Math.max(...bandEdges);
-          // Get data for this layer
-          const data = visualisationDataByLayer[item.layerId];
-          if (Array.isArray(data) && data.length > 0 && minBand !== null && maxBand !== null) {
-            // Extract all metric values
-            const values = data.map(row => {
-              if (typeof row === 'object' && row !== null) {
-                let v = row.value ?? row.metric;
-                if (v === undefined) {
-                  for (const k in row) {
-                    if (typeof row[k] === 'number') return row[k];
+        if (classMethod === 'c' && layerHasCustomBands) {
+          // Use the raw custom bands directly from state — avoids parsing
+          // formatted label strings (e.g. "10.00K") which would truncate to 10.
+          const customBands = state.layers[item.layerId].customBands.map(Number).filter(v => !isNaN(v));
+          if (customBands.length > 1) {
+            minBand = Math.min(...customBands);
+            maxBand = Math.max(...customBands);
+            // Retrieve data for this layer
+            const data = visualisationDataByLayer[item.layerId];
+            if (Array.isArray(data) && data.length > 0) {
+              // Extract all metric values
+              const values = data.map(row => {
+                if (typeof row === 'object' && row !== null) {
+                  let v = row.value ?? row.metric;
+                  if (v === undefined) {
+                    for (const k in row) {
+                      if (typeof row[k] === 'number') return row[k];
+                    }
                   }
+                  return v;
+                } else if (typeof row === 'number') {
+                  return row;
                 }
-                return v;
-              } else if (typeof row === 'number') {
-                return row;
-              }
-              return null;
-            }).filter(v => v !== null && !isNaN(v));
-            // Determine if bands are manually set (not default)
-            // If bands exactly match min/max of data, treat as default
-            const dataMin = Math.min(...values);
-            const dataMax = Math.max(...values);
-            // Debug log for band/data min/max
-            bandsManuallySet = (minBand < dataMin || maxBand < dataMax);
-            // Only set outOfBand if there are actual data values outside the band range
-            outOfBand = bandsManuallySet && values.some(v => v < minBand || v > maxBand);
-            // If bands are not manually set, never show OutOfBandMessage
-            if (!bandsManuallySet) outOfBand = false;
+                return null;
+              }).filter(v => v !== null && !isNaN(v));
+              // Only show the message when data values genuinely fall outside the custom band range
+              outOfBand = values.some(v => v < minBand || v > maxBand);
+            }
           }
         }
         return (

--- a/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.test.jsx
+++ b/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.test.jsx
@@ -204,3 +204,143 @@ describe("DynamicLegend", () => {
     expect(screen.queryByText("network")).not.toBeInTheDocument();
   });
 });
+
+describe("OutOfBandMessage", () => {
+  const LAYER_ID = "out-of-band-layer";
+
+  // Paint with two numeric interpolation stops, giving a non-empty legend with noStyle=false.
+  const INTERPOLATE_PAINT = {
+    "fill-color": [
+      "interpolate",
+      ["linear"],
+      ["feature-state", "value"],
+      0,
+      "#aabbcc",
+      5000,
+      "#ddeeff",
+    ],
+  };
+
+  const makeMapWithLayer = (layerId, paint) => ({
+    on: jest.fn(),
+    off: jest.fn(),
+    getStyle: jest.fn(() => ({
+      layers: [
+        {
+          id: layerId,
+          type: "fill",
+          metadata: { isStylable: true },
+          paint,
+        },
+      ],
+    })),
+  });
+
+  const renderWithState = (mockMap, state) =>
+    render(
+      <MapContext.Provider value={{ state }}>
+        <AppContext.Provider value={{ defaultBands: [] }}>
+          <PageContext.Provider value={{ pageName: "test" }}>
+            <DynamicLegend map={mockMap} />
+          </PageContext.Provider>
+        </AppContext.Provider>
+      </MapContext.Provider>
+    );
+
+  const triggerStyledata = (mockMap) => {
+    act(() => {
+      const handler = mockMap.on.mock.calls.find(
+        (call) => call[0] === "styledata"
+      )[1];
+      handler();
+    });
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders when class_method is 'c', customBands are set, and data has out-of-band values", () => {
+    const map = makeMapWithLayer(LAYER_ID, INTERPOLATE_PAINT);
+    const state = {
+      filters: [],
+      currentZoom: 10,
+      visualisations: {
+        testVis: { joinLayer: LAYER_ID, data: [{ value: 7000 }] },
+      },
+      layers: {
+        [LAYER_ID]: { class_method: "c", customBands: [0, 5000] },
+      },
+    };
+
+    renderWithState(map, state);
+    triggerStyledata(map);
+
+    expect(
+      screen.getByText(/some data is outside the specified bands/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when all data values are within the custom band range", () => {
+    const map = makeMapWithLayer(LAYER_ID, INTERPOLATE_PAINT);
+    const state = {
+      filters: [],
+      currentZoom: 10,
+      visualisations: {
+        testVis: { joinLayer: LAYER_ID, data: [{ value: 3000 }] },
+      },
+      layers: {
+        [LAYER_ID]: { class_method: "c", customBands: [0, 5000] },
+      },
+    };
+
+    renderWithState(map, state);
+    triggerStyledata(map);
+
+    expect(
+      screen.queryByText(/some data is outside the specified bands/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render when class_method is not 'c'", () => {
+    const map = makeMapWithLayer(LAYER_ID, INTERPOLATE_PAINT);
+    const state = {
+      filters: [],
+      currentZoom: 10,
+      visualisations: {
+        testVis: { joinLayer: LAYER_ID, data: [{ value: 7000 }] },
+      },
+      layers: {
+        [LAYER_ID]: { class_method: "d" },
+      },
+    };
+
+    renderWithState(map, state);
+    triggerStyledata(map);
+
+    expect(
+      screen.queryByText(/some data is outside the specified bands/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render when class_method is 'c' but no customBands are set", () => {
+    const map = makeMapWithLayer(LAYER_ID, INTERPOLATE_PAINT);
+    const state = {
+      filters: [],
+      currentZoom: 10,
+      visualisations: {
+        testVis: { joinLayer: LAYER_ID, data: [{ value: 7000 }] },
+      },
+      layers: {
+        [LAYER_ID]: { class_method: "c" },
+      },
+    };
+
+    renderWithState(map, state);
+    triggerStyledata(map);
+
+    expect(
+      screen.queryByText(/some data is outside the specified bands/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/vis-core/src/Components/MapLayout/MapLayout.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapLayout.test.jsx
@@ -178,13 +178,16 @@ jest.mock("Components", () => ({
       </>
     );
   },
-  MapLayerSection: ({ handleColorChange, handleClassificationChange }) => {
+  MapLayerSection: ({ handleColorChange, handleClassificationChange, handleCustomBandsChange }) => {
     return (
       <>
         <span>MapLayerSection</span>
         <button onClick={handleColorChange}>handleColorChange</button>
         <button onClick={handleClassificationChange}>
           handleClassificationChange
+        </button>
+        <button onClick={handleCustomBandsChange}>
+          handleCustomBandsChange
         </button>
       </>
     );
@@ -240,6 +243,16 @@ describe("MapLayout component test", () => {
     expect(mockMapContext.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "UPDATE_CLASSIFICATION_METHOD",
+      })
+    );
+    // handleCustomBandsChange is called
+    const handleCustomBandsChangeButton = screen.getByRole("button", {
+      name: "handleCustomBandsChange",
+    });
+    await userEvent.click(handleCustomBandsChangeButton);
+    expect(mockMapContext.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "UPDATE_CUSTOM_BANDS",
       })
     );
   });

--- a/packages/vis-core/src/Components/MapLayout/MapVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapVisualisation.jsx
@@ -535,8 +535,11 @@ export const MapVisualisation = ({
 
     const currentCustomBands = layerConfig?.customBands;
     const prevCustomBands = prevCustomBandsRef.current[layerKey];
+    // Use `in` to distinguish "never initialised" (key absent) from "initialised but
+    // no custom bands yet" (key present with undefined/null). This ensures the
+    // transition from no custom bands to the first custom bands assignment is detected.
     const customBandsHasChanged =
-      prevCustomBands !== undefined &&
+      (layerKey in prevCustomBandsRef.current) &&
       !areNumericArraysEqual(currentCustomBands, prevCustomBands);
 
     const needUpdate =

--- a/packages/vis-core/src/Components/MapLayout/MapVisualisation.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapVisualisation.test.jsx
@@ -394,6 +394,82 @@ describe("reclassifyAndStyleMap is called", () => {
   });
 });
 
+describe("customBandsHasChanged triggers reclassification", () => {
+  const baseVisualisationData = [
+    { feature_collection: JSON.stringify({ element: "first" }) },
+  ];
+
+  const baseVisualisation = {
+    shouldFilterDataToViewport: true,
+    style: "line-continuous",
+    type: "joinDataToMap",
+    joinLayer: "visualisationName",
+  };
+
+  beforeEach(() => {
+    useFetchVisualisationData.mockReturnValue({
+      data: baseVisualisationData,
+      isLoading: false,
+      error: false,
+      dataWasReturnedButFiltered: false,
+      fetchState: DataFetchState.SUCCESS,
+      resetFetchState: jest.fn(),
+    });
+    hasAnyGeometryNotNull.mockReturnValue(true);
+    reclassifyData.mockReturnValue("#More9Caracters");
+    props.map.getStyle.mockReturnValue({ layers: [{ id: "firstLayersID" }] });
+    props.map.getLayer.mockReturnValue({ id: "mock-layer" });
+    props.map.isStyleLoaded.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("triggers reclassification when customBands are set for the first time", async () => {
+    const contextNoCustomBands = {
+      ...mockMapContext,
+      state: {
+        ...mockMapContext.state,
+        visualisations: { visualisationName: baseVisualisation },
+        layers: { visualisationName: {} },
+      },
+    };
+
+    const { rerender } = render(
+      <AppContext.Provider value={mockAppContext}>
+        <MapContext.Provider value={contextNoCustomBands}>
+          <MapVisualisation {...props} />
+        </MapContext.Provider>
+      </AppContext.Provider>
+    );
+
+    // Wait for the initial reclassification to complete, then reset mocks.
+    await waitFor(() => expect(reclassifyData).toHaveBeenCalled());
+    jest.clearAllMocks();
+    reclassifyData.mockReturnValue("#More9Caracters");
+
+    // Re-render with customBands set for the first time.
+    const contextWithCustomBands = {
+      ...contextNoCustomBands,
+      state: {
+        ...contextNoCustomBands.state,
+        layers: { visualisationName: { customBands: [0, 5000] } },
+      },
+    };
+
+    rerender(
+      <AppContext.Provider value={mockAppContext}>
+        <MapContext.Provider value={contextWithCustomBands}>
+          <MapVisualisation {...props} />
+        </MapContext.Provider>
+      </AppContext.Provider>
+    );
+
+    await waitFor(() => expect(reclassifyData).toHaveBeenCalled());
+  });
+});
+
 describe("the props left is equal to true", () => {
   beforeEach(() => {
     props = {


### PR DESCRIPTION
fix custom banding to not trigger out of band message when it is within range (this was due to upgrade to formatNumber as it was assuming 150K was 150 etc when creating legendEntriesNumeric, this has been changed to just retrieve numerics before they get formatted into legend vals). also fix so when manually selecting custom, the user can updating banding as this was blocked as it was not updating as it was not entering the code to update state as it was expecting all bins to be of numeric, so the "K" addition meant this was bypassed.

also have updated tests and they are all successful.