### PR TITLE
[Refactor]: Consolidate filter initialisation pipeline into useMetadataDrivenFilters as single source of truth

### DIFF
--- a/packages/vis-core/src/contexts/MapContext.jsx
+++ b/packages/vis-core/src/contexts/MapContext.jsx
@@ -6,39 +6,21 @@ import {
   extractParamsWithValues,
   processParameters,
   checkSecurityRequirements,
-  sortValues,
-  isValidCondition,
-  applyCondition,
   parseStringToArray,
   getGetParameters,
   buildParamsMap,
   getDefaultLayerBufferSize,
-  applyWhereConditions,
-  buildDeterministicFilterId,
+  buildCategoricalLegendKey,
   getInitialFilterValue,
-  buildCategoricalLegendKey
 } from "utils";
 import { defaultMapStyle, defaultMapZoom, defaultMapCentre } from "defaults";
-import { AppContext, PageContext, FilterContext } from "contexts";
+import { AppContext, PageContext } from "contexts";
 import { ErrorContext } from "./ErrorContext";
 import { api } from "services";
+import { useMetadataDrivenFilters } from "hooks/useMetadataDrivenFilters";
 
 // Create a context for the app configuration
 export const MapContext = createContext();
-
-/**
- * Helper function to check for duplicate values in an array.
- * @function isDuplicateValue
- * @param {Array} values - The array of values.
- * @param {Object} value - The value to check for duplicates.
- * @returns {boolean} True if the value is a duplicate, false otherwise.
- */
-const isDuplicateValue = (values, value) => {
-  return values.some(existingValue => 
-    existingValue.paramValue === value.paramValue &&
-    existingValue.displayValue === value.displayValue
-  );
-};
 
 /**
  * Builds initial categorical cache entries from filter values that define explicit colours.
@@ -87,7 +69,6 @@ const buildCacheSeedFromFilters = (filters = []) => {
 export const MapProvider = ({ children }) => {
   const appContext = useContext(AppContext);
   const pageContext = useContext(PageContext);
-  const { dispatch: filterDispatch } = useContext(FilterContext);
   const errorContext = useContext(ErrorContext);
   const errorDispatch = errorContext?.dispatch ?? (() => {}); // no-op if provider missing
 
@@ -131,210 +112,206 @@ export const MapProvider = ({ children }) => {
     return { state, dispatch };
   }, [state, dispatch]);
 
+  // Core filter pipeline — useMetadataDrivenFilters owns metadata table fetching, filter option building,
+  // FilterContext initialisation, cross-filter correction, and runtime option hiding.
+  // `getInitialFilterValue` is passed so map pages pick up URL-param / persisted-state values.
+  const {
+    filtersWithIds,
+    metadataTables,
+    paramNameToUuidMap,
+    emptyTables,
+    emptyMetadataFilters,
+    isReady: filtersReady,
+  } = useMetadataDrivenFilters({ getInitialValue: getInitialFilterValue });
+
+  // Initialise layers and visualisations from page config.
+  // This is independent of filter init and runs immediately on page change.
   useEffect(() => {
     dispatch({ type: actionTypes.SET_IS_LOADING });
 
-    /**
-     * Fetch and store metadata tables.
-     * @function fetchMetadataTables
-     * @returns {Object} Metadata tables.
-     */
-    const fetchMetadataTables = async () => {
-      const metadataTables = {};
-      const emptyTables = [];
-      
-      for (const table of pageContext.config.metadataTables) {
-        try {
-          const response = await api.baseService.get(table.path);
-          let filteredData = response;
-
-          if (table.where && Array.isArray(table.where)) {
-            for (const condition of table.where) {
-              if (isValidCondition(condition)) {
-                filteredData = applyCondition(filteredData, condition);
-              } else {
-                console.error(`Invalid condition in metadata table ${table.name}:`, condition);
-              }
-            }
-          }
-
-          metadataTables[table.name] = filteredData;
-          
-          // Check if table is empty
-          if (!Array.isArray(filteredData) || filteredData.length === 0) {
-            emptyTables.push(table.name);
-          }
-        } catch (error) {
-          console.error(`Failed to fetch metadata table ${table.name}:`, error);
-          emptyTables.push(table.name);
-        }
-      }
-
-      return { metadataTables, emptyTables };
-    };
-
-    /**
-     * Initialise filters once metadata tables are fetched.
-     * @function initializeFilters
-     * @param {Object} metadataTables - Fetched metadata tables.
-     */
-    const initializeFilters = async (metadataTables) => {
-      const filters = [];
-      const filterState = {};
-      const paramNameToUuidMap = {};
-      const emptyMetadataFilters = [];
-      const usedFilterIds = new Set();
-
-      for (const filter of pageContext.config.filters) {
-        // Build deterministic ID for each filter
-        const deterministicId = buildDeterministicFilterId(filter, usedFilterIds);
-        const filterWithId = { ...filter, id: deterministicId };
-        paramNameToUuidMap[filter.paramName] = filterWithId.id; // Add mapping from paramName to UUID
-
-        switch (filterWithId.type) {
-          case 'map':
-          case 'slider':
-          case 'mapFeatureSelect':
-          case 'mapFeatureSelectWithControls':
-          case 'mapFeatureSelectAndPan':
-          case 'mapViewport':
-            filters.push(filterWithId);
-            break;
-
-          default:
-            // Some filter types don't define `values` (or configs may be incomplete).
-            // Don't hard-crash the page; log and treat as a value-less filter.
-            if (!filterWithId.values || !filterWithId.values.source) {
-              console.error(
-                "[MapContext] Filter is missing `values.source`. This filter will be initialised without selectable values:",
-                filterWithId
-              );
-              filters.push(filterWithId);
-              break;
-            }
-
-            switch (filterWithId.values.source) {
-              case 'local':
-                filters.push(filterWithId);
-                break;
-
-              case 'api':
-                const path = '/api/tame/mvdata';
-                const dataPath = {
-                  dataPath: pageContext.config.visualisations[0].dataPath,
-                };
-                try {
-                  const metadataFilters = await api.baseService.post(path, dataPath, { skipAuth: false });
-                  const apiFilterValues = Object.groupBy(
-                    metadataFilters,
-                    ({ field_name }) => field_name
-                  );
-                  const baseParamName = filterWithId.paramName.includes('DoMinimum')
-                    ? filterWithId.paramName.replace('DoMinimum', '')
-                    : filterWithId.paramName.includes('DoSomething')
-                    ? filterWithId.paramName.replace('DoSomething', '')
-                    : filterWithId.paramName;
-                  filterWithId.values.values = apiFilterValues[baseParamName][0].distinct_values.map((v) => ({
-                    displayValue: v,
-                    paramValue: v,
-                  }));
-                  filters.push(filterWithId);
-                } catch (error) {
-                  console.error('Error fetching metadata filters', error);
-                }
-                break;
-
-              case 'metadataTable':
-                const metadataTable = metadataTables[filterWithId.values.metadataTableName];
-                if (metadataTable && Array.isArray(metadataTable) && metadataTable.length > 0) {
-                  // NEW: apply "where" clause to restrict rows before building values
-                  let rows = metadataTable;
-                  if (filterWithId.values.where) {
-                    rows = applyWhereConditions(metadataTable, filterWithId.values.where);
-                  }
-
-                  let uniqueValues = [];
-                  rows.forEach(option => {
-                    const value = {
-                      displayValue: option[filterWithId.values.displayColumn],
-                      paramValue: option[filterWithId.values.paramColumn],
-                      legendSubtitleText: option[filterWithId.values?.legendSubtitleTextColumn] || null,
-                      infoOnHover: option[filterWithId.values?.infoOnHoverColumn] ?? null,
-                      infoBelowOnChange: option[filterWithId.values?.infoBelowOnChangeColumn] ?? null,
-                    };
-                    if (!isDuplicateValue(uniqueValues, value)) {
-                      uniqueValues.push(value);
-                    }
-                  });
-
-                  // Apply sorting if specified
-                  if (filterWithId.values.sort) {
-                    uniqueValues = sortValues(uniqueValues, filterWithId.values.sort);
-                  }
-
-                  // Apply exclusion if specified
-                  if (filterWithId.values.exclude) {
-                    uniqueValues = uniqueValues.filter(value => !filterWithId.values.exclude.includes(value.paramValue));
-                  }
-
-                  filterWithId.values.values = uniqueValues;
-
-                  if (uniqueValues.length === 0) {
-                    emptyMetadataFilters.push({
-                      filterName: filterWithId.filterName,
-                      paramName: filterWithId.paramName,
-                      metadataTableName: filterWithId.values.metadataTableName,
-                    });
-                  }
-
-                  filters.push(filterWithId);
-                } else {
-                  console.error(`Metadata table ${filterWithId.values.metadataTableName} not found or empty`);
-                }
-                break;
-
-              default:
-                console.error('Unknown filter source:', filterWithId.values.source);
-            }
-        }
-
-        // Initialize filter value using getInitialFilterValue utility
-        // This will check for persisted state first, then fall back to defaults
-        filterState[filterWithId.id] = getInitialFilterValue(filterWithId);
-      }
-
-      // Incorporate 'sides' logic
-      const updatedFilters = filters.map((filter) => {
-        if (filter.visualisations[0].includes('Side')) {
-          const sides =
-            filter.filterName.includes('Left')
-              ? 'left'
-              : filter.filterName.includes('Right')
-              ? 'right'
-              : 'both';
-          return { ...filter, sides };
-        }
-        return filter;
+    // Initialise non-parameterised layers
+    pageContext.config.layers
+      .filter((layer) => !hasRouteParameterOrQuery(layer.path))
+      .forEach((layer) => {
+        const bufferSize = getDefaultLayerBufferSize(layer.geometryType, layer?.bufferSize);
+        dispatch({ type: actionTypes.ADD_LAYER, payload: { [layer.name]: { ...layer, bufferSize } } });
       });
 
+    // Initialise parameterised layers based on corresponding filters
+    pageContext.config.layers
+      .filter((layer) => hasRouteParameterOrQuery(layer.path))
+      .forEach((layer) => {
+        const bufferSize = getDefaultLayerBufferSize(layer.geometryType, layer?.bufferSize);
+        const allParamsWithValues = extractParamsWithValues(layer.path);
+        const excludedParams = ['x', 'y', 'z'];
+        const { params, missingParams } = processParameters(
+          allParamsWithValues,
+          pageContext.config.filters,
+          excludedParams
+        );
+        const updatedPath = updateUrlParameters(layer.path, layer.path, params);
+        dispatch({
+          type: actionTypes.ADD_LAYER,
+          payload: {
+            [layer.name]: {
+              ...layer,
+              path: updatedPath,
+              pathTemplate: layer.path,
+              bufferSize,
+              missingParams,
+            },
+          },
+        });
+      });
+
+    // Initialise visualisations
+    const apiSchema = appContext.apiSchema;
+    pageContext.config.visualisations.forEach((visConfig) => {
+      const apiRoute = visConfig.dataPath;
+      
+      // Collect all GET parameters (path-level + operation-level)
+      const apiParameters = getGetParameters(apiSchema, apiRoute);
+      
+      // Build query and path params maps
+      const queryParams = buildParamsMap(apiParameters, 'query', pageContext.config.filters);
+      const pathParams = buildParamsMap(apiParameters, 'path', pageContext.config.filters);
+      
+      const requiresAuth = checkSecurityRequirements(apiSchema, apiRoute);
+      
+      // If no parameters are marked as required in the schema, set all to required
+      const hasRequiredParams = apiParameters.some((param) => param.required);
+      if (!hasRequiredParams) {
+        Object.keys(queryParams).forEach((key) => {
+          queryParams[key].required = true;
+        });
+        Object.keys(pathParams).forEach((key) => {
+          pathParams[key].required = true;
+        });
+      }
+      dispatch({
+        type: actionTypes.ADD_VISUALISATION,
+        payload: {
+          [visConfig.name]: {
+            ...visConfig,
+            dataPath: apiRoute,
+            queryParams,
+            pathParams,
+            data: [],
+            paintProperty: {},
+            requiresAuth,
+          },
+        },
+      });
+    });
+
+    return () => {
+      dispatch({ type: actionTypes.RESET_CONTEXT });
+    };
+  }, [pageContext]);
+
+  // Sync filter pipeline output to mapReducer once metadata-driven filters ready.
+  // Handles the map-specific concerns the hook intentionally does not own:
+  //   - legacy `api` source resolution
+  //   - `sides` property for dual-map (Left/Right) filter layout (visualisation-specific)
+  //   - error reporting via ErrorContext
+  //   - categorical legend cache seeding
+  //   - mapReducer dispatches (SET_FILTERS, SET_METADATA_TABLES, SET_PAGE_IS_READY, etc.)
+  useEffect(() => {
+    if (!filtersReady) return;
+
+    let cancelled = false;
+    (async () => {
+      // Abort early if any required metadata tables returned no data.
+      if (emptyTables.length > 0) {
+        console.warn('[MapContext] aborting due to empty metadata tables', {
+          pageName: pageContext.pageName,
+          emptyTables,
+        });
+
+        const message =
+          emptyTables.length === 1
+            ? 'The metadata table is empty or contains no valid data. This page requires valid metadata to function properly.'
+            : `${emptyTables.length} metadata tables are empty or contain no valid data. This page requires valid metadata to function properly.`;
+
+        const technicalDetails =
+          emptyTables.length === 1
+            ? `Metadata table: ${emptyTables[0]}\nError: Table "${emptyTables[0]}" returned no data from the API.`
+            : `Empty metadata tables (${emptyTables.length}):\n${emptyTables.map((t) => `- ${t}`).join('\n')}`;
+
+        // Dispatch into ErrorContext reducer so MapContext sets SET_ERROR
+        errorDispatch({
+          type: errorActionTypes.SET_ERROR,
+          payload: {
+            title: 'Configuration Error',
+            subtitle: 'Unable to Load Page',
+            message,
+            supportMessage: 'Please contact support for assistance',
+            supportDetails: 'This issue typically indicates a data configuration problem that requires administrative attention.',
+            technicalDetails,
+          },
+        });
+
+        dispatch({ type: actionTypes.SET_LOADING_FINISHED });
+        return;
+      }
+
+      // Resolve `api` source filters (TAME-specific: fetches distinct values from the data API).
+      // All other sources are already handled by the hook.
+      let processedFilters = filtersWithIds;
+      const apiSourceFilters = filtersWithIds.filter((f) => f.values?.source === 'api');
+      if (apiSourceFilters.length > 0) {
+        try {
+          const path = '/api/tame/mvdata';
+          const dataPath = { dataPath: pageContext.config.visualisations[0].dataPath };
+          const metadataFilters = await api.baseService.post(path, dataPath, { skipAuth: false });
+          if (cancelled) return;
+          const apiFilterValues = Object.groupBy(metadataFilters, ({ field_name }) => field_name);
+          processedFilters = filtersWithIds.map((f) => {
+            if (f.values?.source !== 'api') return f;
+            const baseParamName = f.paramName.includes('DoMinimum')
+              ? f.paramName.replace('DoMinimum', '')
+              : f.paramName.includes('DoSomething')
+              ? f.paramName.replace('DoSomething', '')
+              : f.paramName;
+            return {
+              ...f,
+              values: {
+                ...f.values,
+                values: apiFilterValues[baseParamName][0].distinct_values.map((v) => ({
+                  displayValue: v,
+                  paramValue: v,
+                })),
+              },
+            };
+          });
+        } catch (error) {
+          console.error('Error fetching api source filters', error);
+        }
+      }
+
+      // Apply the `sides` property for dual-map (Left/Right) filter layout.
+      const filtersWithSides = processedFilters.map((filter) => {
+        if (!filter.visualisations?.[0]?.includes('Side')) return filter;
+        const sides = filter.filterName.includes('Left')
+          ? 'left'
+          : filter.filterName.includes('Right')
+          ? 'right'
+          : 'both';
+        return { ...filter, sides };
+      });
+
+      // Report empty metadata filter warnings (non-fatal — page still loads behind error overlay).
       if (emptyMetadataFilters.length > 0) {
         console.warn('[MapContext] empty metadata filters detected', {
           pageName: pageContext.pageName,
           emptyMetadataFilters,
-          filterStateKeys: Object.keys(filterState),
         });
-        console.log('[MapContext] ErrorContext availability before SET_ERROR', {
-          hasErrorContext: !!errorContext,
-          hasErrorDispatch: typeof errorContext?.dispatch === 'function',
-        });
-
         const technicalDetails = emptyMetadataFilters
           .map(
             ({ filterName, paramName, metadataTableName }) =>
               `Filter: ${filterName || paramName}\nParameter: ${paramName}\nMetadata table: ${metadataTableName}`
           )
           .join('\n\n');
-
         errorDispatch({
           type: errorActionTypes.SET_ERROR,
           payload: {
@@ -349,173 +326,28 @@ export const MapProvider = ({ children }) => {
             technicalDetails,
           },
         });
-
-        console.warn('[MapContext] continuing initialization so the page can render behind the error overlay', {
+        console.warn('[MapContext] continuing initialisation so the page can render behind the error overlay', {
           pageName: pageContext.pageName,
         });
       }
 
-      dispatch({ type: actionTypes.SET_FILTERS, payload: updatedFilters });
-      const categoricalLegendSeed = buildCacheSeedFromFilters(updatedFilters);
+      // Sync everything to mapReducer.
+      dispatch({ type: actionTypes.SET_FILTERS, payload: filtersWithSides });
+      dispatch({ type: actionTypes.SET_METADATA_TABLES, payload: metadataTables });
+      dispatch({ type: actionTypes.SET_PARAM_NAME_TO_UUID_MAP, payload: paramNameToUuidMap });
+      const categoricalLegendSeed = buildCacheSeedFromFilters(filtersWithSides);
       if (Object.keys(categoricalLegendSeed).length > 0) {
         dispatch({
           type: actionTypes.MERGE_CATEGORICAL_LEGEND_CACHE,
           payload: categoricalLegendSeed,
         });
       }
-      filterDispatch({ type: 'INITIALIZE_FILTERS', payload: filterState });
-      dispatch({ type: actionTypes.SET_PARAM_NAME_TO_UUID_MAP, payload: paramNameToUuidMap });
-
-      // Set pageIsReady to true once all filters are initialized
       dispatch({ type: actionTypes.SET_PAGE_IS_READY, payload: true });
-    };
-
-    /**
-     * Main async function to manage the workflow.
-     * @function initializeContext
-     */
-    const initializeContext = async () => {
-      // Initialise non-parameterised layers
-      const nonParameterisedLayers = pageContext.config.layers.filter(
-        (layer) => !hasRouteParameterOrQuery(layer.path)
-      );
-      nonParameterisedLayers.forEach((layer) => {
-        const bufferSize = getDefaultLayerBufferSize(layer.geometryType, layer?.bufferSize);
-        dispatch({ type: actionTypes.ADD_LAYER, payload: { [layer.name]: { ...layer, bufferSize } } });
-      });
-
-      // Initialise parameterised layers based on corresponding filters
-      const parameterisedLayers = pageContext.config.layers.filter((layer) =>
-        hasRouteParameterOrQuery(layer.path)
-      );
-      
-      parameterisedLayers.forEach((layer) => {
-        const bufferSize = getDefaultLayerBufferSize(layer.geometryType, layer?.bufferSize);
-      
-        // Extract parameters and their values from the layer path
-        const allParamsWithValues = extractParamsWithValues(layer.path);
-      
-        const excludedParams = ['x', 'y', 'z'];
-      
-        // Process parameters to fill values and find missing ones
-        const { params, missingParams } = processParameters(
-          allParamsWithValues,
-          pageContext.config.filters,
-          excludedParams
-        );
-      
-        // Update the path using the extracted and found parameters.
-        const updatedPath = updateUrlParameters(layer.path, layer.path, params);
-        
-        // Dispatch the layer with the updated path and any missing parameters
-        dispatch({
-          type: actionTypes.ADD_LAYER,
-          payload: {
-            [layer.name]: {
-              ...layer,
-              path: updatedPath,
-              pathTemplate: layer.path,
-              bufferSize,
-              missingParams, // Include missing parameters for later use
-            },
-          },
-        });
-      });
-      
-
-      // Initialise visualisations
-      const visualisationConfig = pageContext.config.visualisations;
-      const apiSchema = appContext.apiSchema;
-      visualisationConfig.forEach((visConfig) => {
-        const apiRoute = visConfig.dataPath;
-
-        // Collect all GET parameters (path-level + operation-level)
-        const apiParameters = getGetParameters(apiSchema, apiRoute);
-
-        // Build query and path params maps
-        const queryParams = buildParamsMap(apiParameters, 'query', pageContext.config.filters);
-        const pathParams = buildParamsMap(apiParameters, 'path', pageContext.config.filters);
-
-        const requiresAuth = checkSecurityRequirements(apiSchema, apiRoute);
-
-        // If no parameters are marked as required in the schema, set all to required
-        const hasRequiredParams = apiParameters.some((param) => param.required);
-        if (!hasRequiredParams) {
-          Object.keys(queryParams).forEach((key) => {
-            queryParams[key].required = true;
-          });
-          Object.keys(pathParams).forEach((key) => {
-            pathParams[key].required = true;
-          });
-        }
-      
-        const visualisation = {
-          ...visConfig,
-          dataPath: apiRoute,
-          queryParams,
-          pathParams,
-          data: [],
-          paintProperty: {},
-          requiresAuth,
-        };
-      
-        dispatch({
-          type: actionTypes.ADD_VISUALISATION,
-          payload: { [visConfig.name]: visualisation },
-        });
-      });
-
-      // Initialise filters
-      const { metadataTables, emptyTables } = await fetchMetadataTables();
-      
-      // Check if any required metadata tables are empty
-      if (emptyTables.length > 0) {
-        console.warn('[MapContext] aborting due to empty metadata tables', {
-          pageName: pageContext.pageName,
-          emptyTables,
-        });
-
-        const message =
-          emptyTables.length === 1
-            ? `The metadata table is empty or contains no valid data. This page requires valid metadata to function properly.`
-            : `${emptyTables.length} metadata tables are empty or contain no valid data. This page requires valid metadata to function properly.`;
-
-          const technicalDetails =
-            emptyTables.length === 1
-              ? `Metadata table: ${emptyTables[0]}\nError: Table "${emptyTables[0]}" returned no data from the API.`
-              : `Empty metadata tables (${emptyTables.length}):\n${emptyTables.map((t) => `- ${t}`).join('\n')}`;
-
-          // Dispatch into ErrorContext reducer so MapContext sets SET_ERROR
-          errorDispatch({
-            type: errorActionTypes.SET_ERROR,
-            payload: {
-              title: 'Configuration Error',
-              subtitle: 'Unable to Load Page',
-              message,
-              supportMessage: 'Please contact support for assistance',
-              supportDetails: 'This issue typically indicates a data configuration problem that requires administrative attention.',
-              technicalDetails,
-            },
-          });
-
-        dispatch({ type: actionTypes.SET_LOADING_FINISHED });
-        return;
-      }
-      
-      dispatch({ type: actionTypes.SET_METADATA_TABLES, payload: metadataTables });
-      await initializeFilters(metadataTables);
-
       dispatch({ type: actionTypes.SET_LOADING_FINISHED });
-    };
+    })();
 
-    initializeContext();
-
-    return () => {
-      dispatch({
-        type: actionTypes.RESET_CONTEXT,
-      });
-    };
-  }, [pageContext]);
+    return () => { cancelled = true; };
+  }, [filtersReady, filtersWithIds, metadataTables, paramNameToUuidMap, emptyTables, emptyMetadataFilters, pageContext]);
 
   return (
     <MapContext.Provider value={contextValue}>

--- a/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
+++ b/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
@@ -26,29 +26,44 @@ async function callMetadataEndpoint(endpoint) {
 
 /**
  * useMetadataDrivenFilters
- * Builds data-driven filters (options sourced from metadata tables) and applies dependency validation.
- * Mirrors MapContext’s pipeline (deterministic IDs, default values, updateFilterValidity) for non-map pages.
+ * Canonical filter initialisation pipeline. Handles metadata table fetching, filter option
+ * building, FilterContext initialisation, and runtime option hiding.
+ *
+ * Params:
+ * - getInitialValue: optional function (filter) => value. Enables injected functions to override
+ *   the default config-driven value resolution. This is particularly useful for using
+ *  `filterPersistence` in map pages. Non-map pages omit this and use the default, though this
+ *  can be overridden.
  *
  * Returns:
- * - { filters, filterState, onFilterChange, isReady }
+ * - { filters, filterState, onFilterChange, isReady } — consumed by all page types.
+ * - { metadataTables, filtersWithIds, paramNameToUuidMap, emptyTables, emptyMetadataFilters }
+ *   — additional data consumed by MapProvider to sync the canonical filter state to mapReducer.
  *
  * Errors:
  * - The hook catches and logs fetch errors and continues with empty tables/filters (resilient UI).
  */
-export function useMetadataDrivenFilters() {
+export function useMetadataDrivenFilters({ getInitialValue = null } = {}) {
   const pageContext = useContext(PageContext);
   const { state: filterState, dispatch: filterDispatch } = useContext(FilterContext);
 
   const [metadataTables, setMetadataTables] = useState({});
   const [filtersWithIds, setFiltersWithIds] = useState([]);
+  const [paramNameToUuidMap, setParamNameToUuidMap] = useState({});
+  const [emptyTables, setEmptyTables] = useState([]);
+  const [emptyMetadataFilters, setEmptyMetadataFilters] = useState([]);
   const [isReady, setIsReady] = useState(false);
 
   // 1) Fetch metadata tables via API (GET/POST supported).
+  //    Reset isReady so MapProvider's sync effect does not fire with stale data during page
+  //    navigation; it will only re-fire once this effect completes and effect 3 sets ready again.
   useEffect(() => {
+    setIsReady(false);
     let cancelled = false;
     const loadTables = async () => {
       try {
         const tables = {};
+        const empty = [];
         for (const table of pageContext.config.metadataTables || []) {
           const response = await callMetadataEndpoint(table);
           let rows = response;
@@ -56,11 +71,18 @@ export function useMetadataDrivenFilters() {
             rows = applyWhereConditions(rows, table.where);
           }
           tables[table.name] = rows;
+          if (!Array.isArray(rows) || rows.length === 0) empty.push(table.name);
         }
-        if (!cancelled) setMetadataTables(tables);
+        if (!cancelled) {
+          setMetadataTables(tables);
+          setEmptyTables(empty);
+        }
       } catch (err) {
         console.error("useMetadataDrivenFilters: failed to fetch metadata tables:", err);
-        if (!cancelled) setMetadataTables({});
+        if (!cancelled) {
+          setMetadataTables({});
+          setEmptyTables([]);
+        }
       }
     };
     loadTables();
@@ -68,11 +90,27 @@ export function useMetadataDrivenFilters() {
   }, [pageContext]);
 
   // 2) Build filters with deterministic IDs and options from metadata tables.
+  //    Only `metadataTable` sources have their options built here. All other sources
+  //    (`local`, `api`, `map`, `slider`, `mapFeatureSelect`, etc.) are treated as
+  //    passthroughs — their values are already in the config or resolved externally.
+  //
+  //    Guard: if there are configured metadata tables but effect 1 hasn't completed yet
+  //    (metadataTables is still the initial {}), bail out. Without this, effect 2 would run
+  //    with empty tables, produce filters with values.values = [], then effect 3 would fire
+  //    setIsReady(true), causing the page to render before real options are available and
+  //    crashing Toggle/Checkbox on filter.values.values[0].paramValue.
   useEffect(() => {
+    const configuredTableCount = (pageContext.config.metadataTables || []).length;
+    if (configuredTableCount > 0 && Object.keys(metadataTables).length === 0) return;
+
     const used = new Set();
+    const uuidMap = {};
+    const emptyFilters = [];
+
     const built = (pageContext.config.filters || []).map((f) => {
       const id = buildDeterministicFilterId(f, used);
       const filter = { ...f, id };
+      uuidMap[f.paramName] = id;
 
       if (filter.values?.source === "metadataTable") {
         const table = metadataTables[filter.values.metadataTableName] || [];
@@ -98,39 +136,45 @@ export function useMetadataDrivenFilters() {
         if (filter.values.exclude) options = options.filter((o) => !filter.values.exclude.includes(o.paramValue));
 
         filter.values = { ...filter.values, values: options };
+
+        if (options.length === 0) {
+          emptyFilters.push({
+            filterName: filter.filterName,
+            paramName: filter.paramName,
+            metadataTableName: filter.values.metadataTableName,
+          });
+        }
       }
 
       return filter;
     });
 
     setFiltersWithIds(built);
+    setParamNameToUuidMap(uuidMap);
+    setEmptyMetadataFilters(emptyFilters);
   }, [pageContext, metadataTables]);
 
   // 3) Initialise defaults into FilterContext (single/multi).
+  //    `getInitialValue` (if provided) replaces the default computation — map pages pass
+  //    `getInitialFilterValue` to pick up URL-param / persisted-state aware values.
   useEffect(() => {
     if (!filtersWithIds.length) return;
 
-    const initial = {};
-    filtersWithIds.forEach((f) => {
-      if (f.shouldBeBlankOnInit) {
-        initial[f.id] = null;
-        return;
-      }
+    const computeDefault = getInitialValue || ((f) => {
+      if (f.shouldBeBlankOnInit) return null;
       if (f.multiSelect && f.shouldInitialSelectAllInMultiSelect) {
-        initial[f.id] = f.defaultValue ?? f.min ?? (f.values?.values || []).map((v) => v.paramValue);
-      } else {
-        initial[f.id] = f.defaultValue ?? f.min ?? f.values?.values?.[0]?.paramValue ?? null;
+        return f.defaultValue ?? f.min ?? (f.values?.values || []).map((v) => v.paramValue);
       }
+      return f.defaultValue ?? f.min ?? f.values?.values?.[0]?.paramValue ?? null;
     });
 
-    filtersWithIds.forEach((f) => {
-      if (typeof initial[f.id] !== "undefined") {
-        filterDispatch({ type: "SET_FILTER_VALUE", payload: { filterId: f.id, value: initial[f.id] } });
-      }
-    });
+    const initial = {};
+    filtersWithIds.forEach((f) => { initial[f.id] = computeDefault(f); });
+
+    filterDispatch({ type: "INITIALIZE_FILTERS", payload: initial });
 
     setIsReady(true);
-  }, [filtersWithIds, filterDispatch]);
+  }, [filtersWithIds, metadataTables, filterDispatch, getInitialValue]);
 
   // 4) Apply dependency validation/hiding (same routine used in MapLayout).
   const validatedFilters = useMemo(() => {
@@ -154,5 +198,17 @@ export function useMetadataDrivenFilters() {
     filterDispatch({ type: "SET_FILTER_VALUE", payload: { filterId: filter.id, value } });
   };
 
-  return { filters: validatedFilters, filterState, onFilterChange, isReady };
+  return {
+    // Consumed by all page types:
+    filters: validatedFilters,
+    filterState,
+    onFilterChange,
+    isReady,
+    // Consumed by MapProvider to sync the canonical filter state to mapReducer:
+    metadataTables,
+    filtersWithIds,
+    paramNameToUuidMap,
+    emptyTables,
+    emptyMetadataFilters,
+  };
 }

--- a/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
+++ b/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useMemo, useState } from "react";
 import { PageContext, FilterContext } from "contexts";
 import { api } from "services";
-import { updateFilterValidity } from "utils";
+import { updateFilterValidity, correctInitialCrossFilterValues, correctRuntimeCrossFilterValues } from "utils";
 import { applyWhereConditions, sortValues, buildDeterministicFilterId } from "utils";
 
 /**
@@ -27,11 +27,11 @@ async function callMetadataEndpoint(endpoint) {
 /**
  * useMetadataDrivenFilters
  * Canonical filter initialisation pipeline. Handles metadata table fetching, filter option
- * building, FilterContext initialisation, and runtime option hiding.
+ * building, FilterContext initialisation, cross-filter correction, and runtime option hiding.
  *
  * Params:
- * - getInitialValue: optional function (filter) => value. Enables injected functions to override
- *   the default config-driven value resolution. This is particularly useful for using
+ * - getInitialValue: optional function (filter) => value. Enables injected functions to override 
+ *   the default config-driven value resolution. This is particularly useful for using 
  *  `filterPersistence` in map pages. Non-map pages omit this and use the default, though this
  *  can be overridden.
  *
@@ -171,7 +171,13 @@ export function useMetadataDrivenFilters({ getInitialValue = null } = {}) {
     const initial = {};
     filtersWithIds.forEach((f) => { initial[f.id] = computeDefault(f); });
 
-    filterDispatch({ type: "INITIALIZE_FILTERS", payload: initial });
+    // Enforce cross-filter constraints on the initial values before dispatching.
+    // Each filter's default is computed independently, so a shouldBeFiltered filter's
+    // default may be invalid given the shouldFilterOthers filter's default selection.
+    // Correcting here prevents the first fetch from using an invalid combination.
+    const correctedInitial = correctInitialCrossFilterValues(filtersWithIds, metadataTables, initial);
+
+    filterDispatch({ type: "INITIALIZE_FILTERS", payload: correctedInitial });
 
     setIsReady(true);
   }, [filtersWithIds, metadataTables, filterDispatch, getInitialValue]);
@@ -182,6 +188,13 @@ export function useMetadataDrivenFilters({ getInitialValue = null } = {}) {
     const stateLike = { filters: filtersWithIds, metadataTables };
     return updateFilterValidity(stateLike, filterState);
   }, [filtersWithIds, metadataTables, filterState, isReady]);
+
+  // 5) Auto-correct shouldBeFiltered filter values at runtime when a
+  //    shouldFilterOthers filter changes and invalidates another filter's selection.
+  useEffect(() => {
+    if (!isReady) return;
+    correctRuntimeCrossFilterValues(validatedFilters, filterState, filterDispatch);
+  }, [validatedFilters, filterState, filterDispatch, isReady]);
 
   /**
    * onFilterChange

--- a/packages/vis-core/src/utils/validation.js
+++ b/packages/vis-core/src/utils/validation.js
@@ -56,6 +56,7 @@ export function updateFilterValidity(state, filterState) {
       ) {
         const sourceName = filter.values.metadataTableName;
         const metadataTable = state.metadataTables[sourceName];
+        if (!metadataTable) return;
 
         const validRows = Array.isArray(selectedValues)
           ? metadataTable.filter((row) => selectedValues.includes(row[filter.values.paramColumn]))
@@ -113,6 +114,119 @@ export function updateFilterValidity(state, filterState) {
   });
 
   return updatedFilters;
+}
+
+/**
+ * Corrects cross-filter constraint violations in an initial filter values map.
+ *
+ * `getInitialFilterValue` computes each filter's default independently, so a
+ * `shouldBeFiltered` filter's default may be invalid given the `shouldFilterOthers`
+ * filter's default selection. This function applies `updateFilterValidity` to the
+ * initial state and corrects any hidden values before the first dispatch, preventing
+ * the first API call from using an invalid parameter combination.
+ *
+ * @param {Array}  filters        - Filter config objects with populated metadata values.
+ * @param {Object} metadataTables - Metadata tables keyed by table name.
+ * @param {Object} initialValues  - Map of { [filterId]: value } to derive corrected values from.
+ * @returns {Object} A new values map with any cross-filter violations corrected.
+ */
+export function correctInitialCrossFilterValues(filters, metadataTables, initialValues) {
+  const pseudoState = { filters, metadataTables };
+  const validated = updateFilterValidity(pseudoState, initialValues);
+
+  const corrected = { ...initialValues };
+
+  validated.forEach((filter) => {
+    if (!filter.shouldBeFiltered || !filter.values?.values) return;
+
+    const currentValue = corrected[filter.id];
+
+    if (filter.multiSelect) {
+      if (!Array.isArray(currentValue) || currentValue.length === 0) return;
+
+      const visibleValues = currentValue.filter((val) =>
+        filter.values.values.some((v) => v.paramValue === val && !v.isHidden),
+      );
+
+      if (visibleValues.length !== currentValue.length) {
+        corrected[filter.id] =
+          visibleValues.length > 0
+            ? visibleValues
+            : filter.values.values.filter((v) => !v.isHidden).map((v) => v.paramValue);
+      }
+    } else {
+      if (currentValue === null || currentValue === undefined) return;
+
+      const currentOption = filter.values.values.find((v) => v.paramValue === currentValue);
+      if (currentOption?.isHidden) {
+        const firstVisible = filter.values.values.find((v) => !v.isHidden);
+        corrected[filter.id] = firstVisible?.paramValue ?? null;
+      }
+    }
+  });
+
+  return corrected;
+}
+
+/**
+ * Corrects cross-filter constraint violations in the current FilterContext state at runtime.
+ *
+ * Called after `validatedFilters` changes (e.g. the user changed a `shouldFilterOthers`
+ * filter). At that point the filter options have been re-narrowed by `updateFilterValidity`,
+ * but the selected values in FilterContext may still reference options that are now hidden.
+ * This function dispatches `SET_FILTER_VALUE` for each such filter to realign the selection
+ * with the new visible set.
+ *
+ * @param {Array}    validatedFilters - Filter configs with `isHidden` already applied.
+ * @param {Object}   filterState      - Current FilterContext state (selected values by filter id).
+ * @param {Function} filterDispatch   - FilterContext dispatch function.
+ * @returns {boolean} True if at least one correction was dispatched.
+ */
+export function correctRuntimeCrossFilterValues(validatedFilters, filterState, filterDispatch) {
+  let corrected = false;
+
+  validatedFilters.forEach((filter) => {
+    if (!filter.shouldBeFiltered || !filter.values?.values) return;
+
+    const currentValue = filterState[filter.id];
+
+    if (filter.multiSelect) {
+      if (!Array.isArray(currentValue) || currentValue.length === 0) return;
+
+      const visibleValues = currentValue.filter((val) =>
+        filter.values.values.some((v) => v.paramValue === val && !v.isHidden),
+      );
+
+      if (visibleValues.length !== currentValue.length) {
+        filterDispatch({
+          type: "SET_FILTER_VALUE",
+          payload: {
+            filterId: filter.id,
+            value:
+              visibleValues.length > 0
+                ? visibleValues
+                : filter.values.values.filter((v) => !v.isHidden).map((v) => v.paramValue),
+            filter,
+          },
+        });
+        corrected = true;
+      }
+    } else {
+      if (currentValue === null || currentValue === undefined) return;
+
+      const currentOption = filter.values.values.find((v) => v.paramValue === currentValue);
+      if (currentOption?.isHidden) {
+        const firstVisible = filter.values.values.find((v) => !v.isHidden);
+        filterDispatch({
+          type: "SET_FILTER_VALUE",
+          payload: { filterId: filter.id, value: firstVisible?.paramValue ?? null, filter },
+        });
+        corrected = true;
+      }
+    }
+  });
+
+  return corrected;
 }
 
 /**

--- a/packages/vis-core/src/utils/validation.test.js
+++ b/packages/vis-core/src/utils/validation.test.js
@@ -1,0 +1,369 @@
+import { correctInitialCrossFilterValues, correctRuntimeCrossFilterValues } from "./validation";
+
+/**
+ * Shared metadata table used across tests.
+ * Each row links a scenario (A/B) to a valid mode (1/2/3).
+ *
+ *   scenario | mode
+ *   -------- | ----
+ *   A        | 1
+ *   A        | 2
+ *   B        | 3
+ *
+ * So when scenario = "A", only modes 1 and 2 are valid.
+ * When scenario = "B", only mode 3 is valid.
+ */
+const TABLE = "options";
+const METADATA_TABLES = {
+  [TABLE]: [
+    { scenario: "A", mode: 1 },
+    { scenario: "A", mode: 2 },
+    { scenario: "B", mode: 3 },
+  ],
+};
+
+/** Filter that drives narrowing of the mode filter (shouldFilterOthers). */
+const scenarioFilter = {
+  id: "scenarioId",
+  filterName: "Scenario",
+  shouldFilterOthers: true,
+  shouldBeFiltered: false,
+  multiSelect: false,
+  values: {
+    metadataTableName: TABLE,
+    paramColumn: "scenario",
+    values: [
+      { paramValue: "A" },
+      { paramValue: "B" },
+    ],
+  },
+};
+
+/** Filter whose visible options are narrowed by scenarioFilter (shouldBeFiltered). */
+const modeFilter = {
+  id: "modeId",
+  filterName: "Mode",
+  shouldFilterOthers: false,
+  shouldBeFiltered: true,
+  multiSelect: false,
+  values: {
+    metadataTableName: TABLE,
+    paramColumn: "mode",
+    values: [
+      { paramValue: 1 },
+      { paramValue: 2 },
+      { paramValue: 3 },
+    ],
+  },
+};
+
+/** Multiselect variant of modeFilter. */
+const modeFilterMulti = { ...modeFilter, multiSelect: true };
+
+const FILTERS = [scenarioFilter, modeFilter];
+const FILTERS_MULTI = [scenarioFilter, modeFilterMulti];
+
+// ---------------------------------------------------------------------------
+
+describe("correctInitialCrossFilterValues", () => {
+  describe("purity", () => {
+    it("does not mutate the input initialValues object", () => {
+      // scenario A makes mode 3 hidden
+      const initialValues = { scenarioId: "A", modeId: 3 };
+      const frozen = Object.freeze({ ...initialValues });
+      // Should not throw despite frozen input (spread creates a new object)
+      const result = correctInitialCrossFilterValues(FILTERS, METADATA_TABLES, initialValues);
+      expect(result).not.toBe(initialValues);
+      // Original is unchanged
+      expect(initialValues.modeId).toBe(3);
+    });
+
+    it("returns a new object reference", () => {
+      const initialValues = { scenarioId: "A", modeId: 1 };
+      const result = correctInitialCrossFilterValues(FILTERS, METADATA_TABLES, initialValues);
+      expect(result).not.toBe(initialValues);
+    });
+  });
+
+  describe("single-select correction", () => {
+    it("leaves a valid value unchanged", () => {
+      // mode 1 is valid when scenario = A
+      const result = correctInitialCrossFilterValues(
+        FILTERS,
+        METADATA_TABLES,
+        { scenarioId: "A", modeId: 1 },
+      );
+      expect(result.modeId).toBe(1);
+    });
+
+    it("replaces a hidden value with the first visible option", () => {
+      // scenario A → only modes 1 and 2 are valid; mode 3 is hidden
+      const result = correctInitialCrossFilterValues(
+        FILTERS,
+        METADATA_TABLES,
+        { scenarioId: "A", modeId: 3 },
+      );
+      expect(result.modeId).toBe(1);
+    });
+
+    it("does not touch a null value", () => {
+      const result = correctInitialCrossFilterValues(
+        FILTERS,
+        METADATA_TABLES,
+        { scenarioId: "A", modeId: null },
+      );
+      expect(result.modeId).toBeNull();
+    });
+
+    it("does not touch an undefined value", () => {
+      const result = correctInitialCrossFilterValues(
+        FILTERS,
+        METADATA_TABLES,
+        { scenarioId: "A", modeId: undefined },
+      );
+      expect(result.modeId).toBeUndefined();
+    });
+
+    it("falls back to null when no visible option exists", () => {
+      // Remove all rows so every mode is hidden
+      const result = correctInitialCrossFilterValues(
+        FILTERS,
+        { [TABLE]: [] },
+        { scenarioId: "A", modeId: 3 },
+      );
+      expect(result.modeId).toBeNull();
+    });
+  });
+
+  describe("multi-select correction", () => {
+    it("leaves a fully valid array unchanged", () => {
+      // modes 1 and 2 are both valid for scenario A
+      const result = correctInitialCrossFilterValues(
+        FILTERS_MULTI,
+        METADATA_TABLES,
+        { scenarioId: "A", modeId: [1, 2] },
+      );
+      expect(result.modeId).toEqual([1, 2]);
+    });
+
+    it("removes hidden values from a partial array", () => {
+      // mode 3 is hidden for scenario A; modes 1 and 2 remain
+      const result = correctInitialCrossFilterValues(
+        FILTERS_MULTI,
+        METADATA_TABLES,
+        { scenarioId: "A", modeId: [1, 2, 3] },
+      );
+      expect(result.modeId).toEqual([1, 2]);
+    });
+
+    it("falls back to all visible options when every selected value is hidden", () => {
+      // scenario A hides mode 3; initial has only mode 3 selected
+      const result = correctInitialCrossFilterValues(
+        FILTERS_MULTI,
+        METADATA_TABLES,
+        { scenarioId: "A", modeId: [3] },
+      );
+      // Visible for scenario A: modes 1 and 2
+      expect(result.modeId).toEqual([1, 2]);
+    });
+
+    it("does not touch an empty array", () => {
+      const result = correctInitialCrossFilterValues(
+        FILTERS_MULTI,
+        METADATA_TABLES,
+        { scenarioId: "A", modeId: [] },
+      );
+      expect(result.modeId).toEqual([]);
+    });
+  });
+
+  describe("no-op cases", () => {
+    it("passes through filters that do not have shouldBeFiltered set", () => {
+      // scenarioId itself is not shouldBeFiltered — it should never be corrected
+      const result = correctInitialCrossFilterValues(
+        FILTERS,
+        METADATA_TABLES,
+        { scenarioId: "A", modeId: 1 },
+      );
+      expect(result.scenarioId).toBe("A");
+    });
+
+    it("returns initialValues unchanged when no cross-filter relationships exist", () => {
+      const standaloneFilter = {
+        id: "colorId",
+        filterName: "Color",
+        shouldFilterOthers: false,
+        shouldBeFiltered: false,
+        multiSelect: false,
+        values: {
+          metadataTableName: TABLE,
+          paramColumn: "scenario",
+          values: [{ paramValue: "A" }, { paramValue: "B" }],
+        },
+      };
+      const initialValues = { colorId: "A" };
+      const result = correctInitialCrossFilterValues(
+        [standaloneFilter],
+        METADATA_TABLES,
+        initialValues,
+      );
+      expect(result).toEqual(initialValues);
+    });
+
+    it("leaves filter values not in metadataTables untouched", () => {
+      const result = correctInitialCrossFilterValues(
+        FILTERS,
+        {},           // no metadata tables at all
+        { scenarioId: "A", modeId: 3 },
+      );
+      // updateFilterValidity can't narrow anything without the table, so modeId stays
+      expect(result.modeId).toBe(3);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// correctRuntimeCrossFilterValues
+// ---------------------------------------------------------------------------
+// These tests use pre-validated filter objects (isHidden already applied),
+// which is the shape produced by updateFilterValidity. No metadata tables
+// are needed because the hiding decision has already been made.
+
+/**
+ * Builds a validated filter config with isHidden applied to each option.
+ * hiddenValues lists paramValues that should be marked isHidden: true.
+ */
+function makeValidatedFilter({ id, filterName = "Filter", multiSelect = false, options, hiddenValues = [] }) {
+  return {
+    id,
+    filterName,
+    shouldBeFiltered: true,
+    multiSelect,
+    values: {
+      values: options.map((v) => ({
+        paramValue: v,
+        isHidden: hiddenValues.includes(v),
+      })),
+    },
+  };
+}
+
+describe("correctRuntimeCrossFilterValues", () => {
+  let dispatch;
+
+  beforeEach(() => {
+    dispatch = jest.fn();
+  });
+
+  describe("return value", () => {
+    it("returns false when no correction is needed", () => {
+      const filter = makeValidatedFilter({ id: "modeId", options: [1, 2, 3] });
+      const result = correctRuntimeCrossFilterValues([filter], { modeId: 1 }, dispatch);
+      expect(result).toBe(false);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it("returns true when a correction is dispatched", () => {
+      const filter = makeValidatedFilter({ id: "modeId", options: [1, 2, 3], hiddenValues: [1] });
+      const result = correctRuntimeCrossFilterValues([filter], { modeId: 1 }, dispatch);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("single-select correction", () => {
+    it("dispatches SET_FILTER_VALUE with the first visible option when current is hidden", () => {
+      const filter = makeValidatedFilter({ id: "modeId", options: [1, 2, 3], hiddenValues: [1] });
+      correctRuntimeCrossFilterValues([filter], { modeId: 1 }, dispatch);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "SET_FILTER_VALUE",
+        payload: { filterId: "modeId", value: 2, filter },
+      });
+    });
+
+    it("dispatches null when every option is hidden", () => {
+      const filter = makeValidatedFilter({ id: "modeId", options: [1, 2], hiddenValues: [1, 2] });
+      correctRuntimeCrossFilterValues([filter], { modeId: 1 }, dispatch);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "SET_FILTER_VALUE",
+        payload: { filterId: "modeId", value: null, filter },
+      });
+    });
+
+    it("does not dispatch when current value is visible", () => {
+      const filter = makeValidatedFilter({ id: "modeId", options: [1, 2, 3], hiddenValues: [3] });
+      correctRuntimeCrossFilterValues([filter], { modeId: 1 }, dispatch);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it("does not dispatch when current value is null", () => {
+      const filter = makeValidatedFilter({ id: "modeId", options: [1, 2], hiddenValues: [1] });
+      correctRuntimeCrossFilterValues([filter], { modeId: null }, dispatch);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it("does not dispatch when current value is undefined", () => {
+      const filter = makeValidatedFilter({ id: "modeId", options: [1, 2], hiddenValues: [1] });
+      correctRuntimeCrossFilterValues([filter], { modeId: undefined }, dispatch);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("multi-select correction", () => {
+    it("dispatches with only the visible subset when some are hidden", () => {
+      const filter = makeValidatedFilter({
+        id: "modeId", multiSelect: true, options: [1, 2, 3], hiddenValues: [3],
+      });
+      correctRuntimeCrossFilterValues([filter], { modeId: [1, 2, 3] }, dispatch);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "SET_FILTER_VALUE",
+        payload: { filterId: "modeId", value: [1, 2], filter },
+      });
+    });
+
+    it("dispatches all visible options when every selected value is hidden", () => {
+      const filter = makeValidatedFilter({
+        id: "modeId", multiSelect: true, options: [1, 2, 3], hiddenValues: [1, 2],
+      });
+      correctRuntimeCrossFilterValues([filter], { modeId: [1, 2] }, dispatch);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "SET_FILTER_VALUE",
+        payload: { filterId: "modeId", value: [3], filter },
+      });
+    });
+
+    it("does not dispatch when all selected values are visible", () => {
+      const filter = makeValidatedFilter({
+        id: "modeId", multiSelect: true, options: [1, 2, 3], hiddenValues: [3],
+      });
+      correctRuntimeCrossFilterValues([filter], { modeId: [1, 2] }, dispatch);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it("does not dispatch for an empty array", () => {
+      const filter = makeValidatedFilter({
+        id: "modeId", multiSelect: true, options: [1, 2], hiddenValues: [1],
+      });
+      correctRuntimeCrossFilterValues([filter], { modeId: [] }, dispatch);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("no-op cases", () => {
+    it("skips filters without shouldBeFiltered", () => {
+      const filter = {
+        id: "scenarioId",
+        shouldBeFiltered: false,
+        values: { values: [{ paramValue: "A", isHidden: false }] },
+      };
+      correctRuntimeCrossFilterValues([filter], { scenarioId: "A" }, dispatch);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it("dispatches once per corrected filter across multiple filters", () => {
+      const filterA = makeValidatedFilter({ id: "aId", options: [1, 2], hiddenValues: [1] });
+      const filterB = makeValidatedFilter({ id: "bId", options: [3, 4], hiddenValues: [3] });
+      correctRuntimeCrossFilterValues([filterA, filterB], { aId: 1, bId: 3 }, dispatch);
+      expect(dispatch).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
### Summary

Eliminates the duplicated filter initialisation pipeline between MapContext.jsx and useMetadataDrivenFilters.jsx. The hook is now the canonical pipeline for all page types. `MapProvider` delegates to it and retains only map-specific concerns.

Closes #214.

Additionally, provides a couple of validation functions which run on initialisation and during runtime, that gate the setting of filter context until fully validated combinations are settled on.

Closes #213.

---

### What changed

#### `src/hooks/useMetadataDrivenFilters.jsx`

- **New option `{ getInitialValue }`**: optional `(filter) => value` callback to enable `filterPersistence` functionality within the hook. Defaults still valid for non-map pages.
- **New state**: `paramNameToUuidMap`, `emptyTables`, `emptyMetadataFilters`
- **Effect 1** now calls `setIsReady(false)` before fetching, preventing `MapProvider`'s sync effect from firing with stale data during page navigation. Tracks which tables returned no rows.
- **Effect 2** now handles `metadataTable` source only. All other sources (`local`, `api`, `map`, `slider`, `mapFeatureSelect`, etc.) are treated as passthroughs — their values are already in the config or resolved externally. Builds `paramNameToUuidMap` and tracks `emptyMetadataFilters`.
- **Effect 3** uses `getInitialValue` if provided, otherwise falls back to the hook's own default computation (identical to previous non-map behaviour).
- **Return value** extended with MapContext-specific dependencies.

#### `src/contexts/MapContext.jsx`

- **Imports cleaned**: removed unneeded utility/context imports
- **Removed**: `isDuplicateValue` helper (was only used inside the now-deleted `initializeFilters`).
- **Removed**: `const { dispatch: filterDispatch } = useContext(FilterContext)` — no longer needed.
- **Added**: `useMetadataDrivenFilters({ getInitialValue: getInitialFilterValue })` hook call.
- **Replaced the ~400-line monolithic `useEffect`** with two focused effects:
  - **Effect A — Layer/Visualisation init** `[pageContext]`: synchronous, dispatches `ADD_LAYER` and `ADD_VISUALISATION`, sets `RESET_CONTEXT` on cleanup. Unchanged behaviour.
  - **Effect B — Filter sync** `[filtersReady, filtersWithIds, …]`: async, guarded by `if (!filtersReady) return`. Handles `api` source resolution, `sides` property, error reporting, mapReducer dispatches. Fires once per page after the hook is ready.

#### `src/utils/validation.js` / validation.test.js

- `correctInitialCrossFilterValues(validatedFilters, filterState, filterDispatch)`
- `correctRuntimeCrossFilterValues(validatedFilters, filterState, filterDispatch)` added as a pure utility.
- Tests added for both.

---

### What didn't change

- **Non-map page behaviour**: `DirectoryScorecardsPage` and `SvgGalleryManager` destructure only `{ filters, filterState, onFilterChange, isReady }` — the new return fields are additive and don't affect them.
- **Map page initialisation sequence**: same metadata table fetch → filter build → FilterContext init → api source resolution → sides → mapReducer sync.
- **Error handling**: empty tables abort with `SET_ERROR`; empty metadata filters warn and continue (page loads behind error overlay).
- **`api` source resolution**: kept in `MapProvider` because it requires knowledge of `pageContext.config.visualisations[0].dataPath` — a TAME-specific concern that doesn't belong in a generic hook.

---

### Design decisions

| Decision | Rationale |
|---|---|
| `getInitialValue` injected as an option | Keeps the hook decoupled from `getInitialFilterValue` (a persistence/URL utility). Non-map pages don't need it. |
| `api` source stays in MapProvider | TAME-specific endpoint — a generic hook shouldn't know about `/api/tame/mvdata`. |
| `sides` logic stays in MapProvider | Dual-map UI concern — not relevant to `DirectoryScorecardsPage` or `SvgGalleryManager`. |
| `setIsReady(false)` in effect 1 | Prevents filter sync effect from firing with stale data when `pageContext` changes and `MapProvider` stays mounted. |
| Hook still calls `filterDispatch` internally | Keeps `FilterContext` initialisation encapsulated in the pipeline. `MapProvider` only dispatches to `mapReducer`. |

---

### Testing

- 27 new tests for cross-filter correction utilities in validation.test.js.
- validation.test.js, `MapLayout.test.jsx`, `MapVisualisation.test.jsx`, `Map.test.jsx`, `useMetadataDrivenFilters` — all PASS.