### PR TITLE
Dark Base Map

### DIFF
--- a/packages/vis-core/src/Components/MapLayout/DualMaps.jsx
+++ b/packages/vis-core/src/Components/MapLayout/DualMaps.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import { DynamicLegend } from "Components";
 import { useDualMaps, useMapContext, useFilterContext } from "hooks";
+import { actionTypes } from "reducers";
 import maplibregl from "maplibre-gl";
 import { api } from "services";
 
@@ -21,12 +22,14 @@ import {
 import "./MapLayout.css";
 import { VisualisationManager } from "./VisualisationManager";
 import { Layer } from './Layer'
+import MapStyleToggle from "./MapStyleToggle";
 import "./MapLayout.css";
 
 const Wrap = styled.div`
   display: flex;
   height: 100%;
   width: 100%;
+  position: relative;
   @media ${props => props.theme.mq.mobile} {
     flex-direction: column;
     height: auto; /* let content dictate height */
@@ -61,6 +64,13 @@ const StyledMapContainer = styled.div`
 `;
 
 /**
+ * Safely get a source id from a MapLibre style layer.
+ */
+function getLayerSourceId(layer) {
+  return typeof layer?.source === "string" ? layer.source : null;
+}
+
+/**
  * DualMaps component that renders two synchronized maps side by side using MapLibre GL and handles layers,
  * including hover and click interactions.
  *
@@ -69,9 +79,27 @@ const StyledMapContainer = styled.div`
 const DualMaps = (props) => {
   const leftMapContainerRef = useRef(null);
   const rightMapContainerRef = useRef(null);
+  const appliedMapStyleRef = useRef({ left: null, right: null });
+
+  /**
+   * Local fallback refs for known base source ids.
+   *
+   * Ideally useDualMaps should eventually return one knownBaseSourceIds ref per map,
+   * like useMap does for the single map. Until then, DualMaps keeps its own refs here.
+   */
+  const localKnownBaseSourceIdsRef = useRef({
+    left: null,
+    right: null,
+  });
+
+  const hasDispatchedInitialBaseSourceIdsRef = useRef({
+    left: false,
+    right: false,
+  });
+
   const { state, dispatch } = useMapContext();
   const { mapStyle, mapCentre, mapZoom } = state;
-  const { leftMap, rightMap, isMapReady } = useDualMaps(
+  const dualMapResult = useDualMaps(
     leftMapContainerRef,
     rightMapContainerRef,
     mapStyle,
@@ -79,6 +107,21 @@ const DualMaps = (props) => {
     mapZoom,
     props.extraCopyrightText
   );
+
+  const {
+    leftMap,
+    rightMap,
+    isMapReady,
+
+    /**
+     * These are optional. This lets this component work now even if useDualMaps
+     * does not return them yet.
+     */
+    leftKnownBaseSourceIds,
+    rightKnownBaseSourceIds,
+    knownBaseSourceIds,
+  } = dualMapResult;
+
   const { dispatch: filterDispatch } = useFilterContext();
 
   const maps = { left: leftMap, right: rightMap };
@@ -90,6 +133,247 @@ const DualMaps = (props) => {
   const hoverEventIdRef = useRef(0);
   const hoverInfoRef = useRef({ left: {}, right: {} });
   const prevHoveredFeaturesRef = useRef({ left: [], right: [] });
+
+  /**
+   * Resolve the known base-source-id Set for one side.
+   *
+   * Priority:
+   * 1. useDualMaps side-specific ref if available
+   * 2. useDualMaps shared object/ref if available
+   * 3. local DualMaps fallback ref
+   * 4. last-resort capture from current map style
+   */
+  const getKnownBaseSourceIdsForSide = useCallback(
+    (side) => {
+      const map = side === "left" ? leftMap : rightMap;
+
+      const sideSpecificHookRef =
+        side === "left" ? leftKnownBaseSourceIds : rightKnownBaseSourceIds;
+
+      if (sideSpecificHookRef?.current) {
+        return sideSpecificHookRef.current;
+      }
+
+      if (knownBaseSourceIds?.[side]?.current) {
+        return knownBaseSourceIds[side].current;
+      }
+
+      if (knownBaseSourceIds?.current?.[side]) {
+        return knownBaseSourceIds.current[side];
+      }
+
+      if (localKnownBaseSourceIdsRef.current[side]) {
+        return localKnownBaseSourceIdsRef.current[side];
+      }
+
+      if (map) {
+        const style = map.getStyle();
+        const ids = new Set(Object.keys(style?.sources ?? {}));
+        localKnownBaseSourceIdsRef.current[side] = ids;
+        return ids;
+      }
+
+      return new Set(state.baseSourceIds ?? []);
+    },
+    [
+      leftMap,
+      rightMap,
+      leftKnownBaseSourceIds,
+      rightKnownBaseSourceIds,
+      knownBaseSourceIds,
+      state.baseSourceIds,
+    ]
+  );
+
+  /**
+   * Store the known base-source-id Set for one side.
+   */
+  const setKnownBaseSourceIdsForSide = useCallback(
+    (side, idsSet) => {
+      const sideSpecificHookRef =
+        side === "left" ? leftKnownBaseSourceIds : rightKnownBaseSourceIds;
+
+      if (sideSpecificHookRef) {
+        sideSpecificHookRef.current = idsSet;
+      }
+
+      if (knownBaseSourceIds?.[side]) {
+        knownBaseSourceIds[side].current = idsSet;
+      }
+
+      if (knownBaseSourceIds?.current && typeof knownBaseSourceIds.current === "object") {
+        knownBaseSourceIds.current[side] = idsSet;
+      }
+
+      localKnownBaseSourceIdsRef.current[side] = idsSet;
+    },
+    [leftKnownBaseSourceIds, rightKnownBaseSourceIds, knownBaseSourceIds]
+  );
+
+  /**
+   * Capture and dispatch initial base source ids for each side.
+   *
+   * This mirrors the single-map Map.jsx behaviour, but keeps each side separate.
+   */
+  useEffect(() => {
+    ["left", "right"].forEach((side) => {
+      const map = maps[side];
+      if (!map) return;
+      if (hasDispatchedInitialBaseSourceIdsRef.current[side]) return;
+
+      const idsSet = getKnownBaseSourceIdsForSide(side);
+      if (!idsSet || idsSet.size === 0) return;
+
+      const ids = Array.from(idsSet);
+
+      dispatch({
+        type: actionTypes.SET_BASE_SOURCE_IDS,
+        payload: ids,
+      });
+
+      hasDispatchedInitialBaseSourceIdsRef.current[side] = true;
+
+      console.log(`[DualMaps] Dispatched initial base source IDs for ${side}:`, ids);
+    });
+  }, [
+    leftMap,
+    rightMap,
+    getKnownBaseSourceIdsForSide,
+    dispatch,
+  ]);
+
+  /**
+   * Creates a transformStyle callback for one side of the dual map.
+   *
+   * This preserves custom/app sources and layers when switching the basemap.
+   */
+  const createTransformStyleForSide = useCallback(
+    (side) => {
+      return (previousStyle, nextStyle) => {
+        const previousBaseSourceIds = getKnownBaseSourceIdsForSide(side);
+
+        /**
+         * Custom sources are anything in the current/previous style that was
+         * NOT part of the previous basemap.
+         */
+        const customSourceEntries = Object.entries(
+          previousStyle.sources ?? {}
+        ).filter(([sourceId]) => !previousBaseSourceIds.has(sourceId));
+
+        const customSources = Object.fromEntries(customSourceEntries);
+
+        const customSourceIds = new Set(
+          customSourceEntries.map(([sourceId]) => sourceId)
+        );
+
+        /**
+         * Custom layers are layers attached to custom sources.
+         */
+        const customLayers = (previousStyle.layers ?? []).filter((layer) => {
+          const sourceId = getLayerSourceId(layer);
+          if (!sourceId) return false;
+
+          return (
+            customSourceIds.has(sourceId) ||
+            !previousBaseSourceIds.has(sourceId)
+          );
+        });
+
+        /**
+         * The incoming style is now the new basemap. Store its source ids as
+         * the latest known base source ids for this side.
+         */
+        const nextBaseSourceIds = new Set(
+          Object.keys(nextStyle.sources ?? {})
+        );
+
+        setKnownBaseSourceIdsForSide(side, nextBaseSourceIds);
+
+        dispatch({
+          type: actionTypes.SET_BASE_SOURCE_IDS,
+          payload: Array.from(nextBaseSourceIds),
+        });
+
+        /**
+         * Avoid duplicate layer IDs if the incoming basemap has any layer with
+         * the same ID as one of our custom layers.
+         */
+        const nextLayerIds = new Set(
+          (nextStyle.layers ?? []).map((layer) => layer.id)
+        );
+
+        const safeCustomLayers = customLayers.filter(
+          (layer) => !nextLayerIds.has(layer.id)
+        );
+
+        const mergedStyle = {
+          ...nextStyle,
+          sources: {
+            ...(nextStyle.sources ?? {}),
+            ...customSources,
+          },
+          layers: [
+            ...(nextStyle.layers ?? []),
+            ...safeCustomLayers,
+          ],
+        };
+
+        return mergedStyle;
+      };
+    },
+    [
+      getKnownBaseSourceIdsForSide,
+      setKnownBaseSourceIdsForSide,
+      dispatch,
+    ]
+  );
+
+  /**
+   * Runtime style switching for both maps.
+   *
+   * Uses MapLibre transformStyle so custom app sources/layers stay visible
+   * when toggling between light and dark basemaps.
+   */
+  useEffect(() => {
+    if (!maps.left || !maps.right || !state.mapStyle) return;
+
+    const nextMapStyle =
+      typeof state.mapStyle === "function" ? state.mapStyle() : state.mapStyle;
+
+    if (
+      appliedMapStyleRef.current.left === null &&
+      appliedMapStyleRef.current.right === null
+    ) {
+      appliedMapStyleRef.current = {
+        left: nextMapStyle,
+        right: nextMapStyle,
+      };
+      return;
+    }
+
+    if (appliedMapStyleRef.current.left !== nextMapStyle) {
+      appliedMapStyleRef.current.left = nextMapStyle;
+
+      maps.left.setStyle(nextMapStyle, {
+        diff: true,
+        transformStyle: createTransformStyleForSide("left"),
+      });
+    }
+
+    if (appliedMapStyleRef.current.right !== nextMapStyle) {
+      appliedMapStyleRef.current.right = nextMapStyle;
+
+      maps.right.setStyle(nextMapStyle, {
+        diff: true,
+        transformStyle: createTransformStyleForSide("right"),
+      });
+    }
+  }, [
+    leftMap,
+    rightMap,
+    state.mapStyle,
+    createTransformStyleForSide,
+  ]);
 
   /**
    * Generates HTML for metadata section of tooltips
@@ -487,6 +771,15 @@ const DualMaps = (props) => {
               ({ feature, layerId, featureName, joinToDefault }) => {
                 const layerConfig = state.layers[layerId];
                 const customTooltip = layerConfig?.customTooltip;
+
+                if (!customTooltip) {
+                  return Promise.resolve(
+                    joinToDefault
+                      ? "<p>Data unavailable.</p>"
+                      : buildErrorTooltip(featureName)
+                  );
+                }
+
                 const { htmlTemplate, customFormattingFunctions } = customTooltip;
                 const featureId = feature.id;
                 const requestUrlResolved = resolveTooltipRequestUrl(customTooltip, featureId);
@@ -571,7 +864,7 @@ const DualMaps = (props) => {
         }
       });
     },
-    [maps, state.layers, state.visualisations]
+    [leftMap, rightMap, state.layers, state.visualisations, generateMetadataHtml]
   );
 
 
@@ -584,6 +877,7 @@ const DualMaps = (props) => {
   const handleLayerClick = (e, layerId, bufferSize) => {
     ["left", "right"].forEach((side) => {
       const map = maps[side];
+      if (!map) return;
 
       if (popups[side]?.[layerId]?.length) {
         popups[side][layerId].forEach((popup) => popup.remove());
@@ -645,7 +939,7 @@ const DualMaps = (props) => {
         }
       });
     },
-    [maps]
+    [leftMap, rightMap]
   );
 
    /**
@@ -661,10 +955,11 @@ const DualMaps = (props) => {
     (labelZoomLevel, layerId, sourceLayerName, labelNulls) => {
       ["left", "right"].forEach((side) => {
         const map = maps[side];
+        if (!map) return;
         const mapZoomLevel = map.getZoom();
 
         dispatch({
-          type: "STORE_CURRENT_ZOOM",
+          type: actionTypes.STORE_CURRENT_ZOOM,
           payload: mapZoomLevel,
         });
 
@@ -680,7 +975,7 @@ const DualMaps = (props) => {
             });
             
             if (features.length > 0) {
-              const geometryType = features[0].geometry.type
+              const geometryType = features[0].geometry.type;
               
               // Determine symbol placement based on geometry type
               let symbolPlacement = 'point'; // Default to point
@@ -717,7 +1012,7 @@ const DualMaps = (props) => {
         }
       });
     },
-    [maps]
+    [leftMap, rightMap, dispatch]
   );
 
   useEffect(() => {
@@ -726,6 +1021,7 @@ const DualMaps = (props) => {
     Object.keys(state.layers).forEach((layerId) => {
       ["left", "right"].forEach((side) => {
         const map = maps[side];
+
         if (state.layers[layerId].shouldHaveLabel) {
           const layerData = state.layers[layerId];
           const zoomLevel = layerData.labelZoomLevel || 12;
@@ -776,21 +1072,23 @@ const DualMaps = (props) => {
       Object.keys(state.layers).forEach((layerId) => {
         ["left", "right"].forEach((side) => {
           const map = maps[side];
+          if (!map) return;
+
           if (state.layers[layerId].shouldHaveTooltipOnClick) {
             const { clickCallback, hoverCallback, zoomHandler } =
-              listenerCallbackRef.current[layerId];
-            map.off("click", clickCallback);
-            map.off("mousemove", hoverCallback);
-            map.off('zoomend', zoomHandler);
+              listenerCallbackRef.current[layerId] || {};
+            if (clickCallback) map.off("click", clickCallback);
+            if (hoverCallback) map.off("mousemove", hoverCallback);
+            if (zoomHandler) map.off('zoomend', zoomHandler);
           }
           if (state.layers[layerId].shouldHaveLabel) {
             const zoomHandler = listenerCallbackRef.current[layerId]?.zoomHandler;
-            map.off('zoomend', zoomHandler);
+            if (zoomHandler) map.off('zoomend', zoomHandler);
           }
         });
       });
     };
-  }, [maps, handleLayerLeave, state.layers, state.visualisations]);
+  }, [leftMap, rightMap, handleLayerLeave, handleMapHover, handleZoom, state.layers, state.visualisations]);
 
   /**
    * Handles map click events and dispatches actions based on the clicked feature.
@@ -812,6 +1110,8 @@ const DualMaps = (props) => {
       mapFilters.forEach((filter) => {
         ["left", "right"].forEach((side) => {
           const map = maps[side];
+          if (!map) return;
+
           const features = map.queryRenderedFeatures(point, {
             layers: [filter.layer],
           });
@@ -874,25 +1174,25 @@ const DualMaps = (props) => {
         });
       });
     },
-    [isMapReady, maps, state.filters, dispatch]
+    [isMapReady, leftMap, rightMap, state.filters, dispatch, filterDispatch]
   );
 
   // Run once to set the state of the map
   useEffect(() => {
     if (isMapReady) {
       dispatch({
-        type: "SET_MAP",
+        type: actionTypes.SET_MAP,
         payload: { map: maps.left },
       });
       dispatch({
-        type: "SET_DUAL_MAPS",
+        type: actionTypes.SET_DUAL_MAPS,
         payload: { maps: [maps.left, maps.right] },
       });
     }
-  }, [isMapReady]);
+  }, [isMapReady, leftMap, rightMap, dispatch]);
 
   useEffect(() => {
-    if (isMapReady & (state.filters.length > 0)) {
+    if (isMapReady && (state.filters.length > 0)) {
       const hasMapFilter = state.filters.some(
         (filter) => filter.type === "map"
       );
@@ -910,7 +1210,7 @@ const DualMaps = (props) => {
         });
       }
     };
-  }, [isMapReady, maps, handleMapClick]);
+  }, [isMapReady, leftMap, rightMap, handleMapClick, state.filters]);
 
   useEffect(() => {
   if (!leftMap || !rightMap) return;
@@ -929,8 +1229,15 @@ const DualMaps = (props) => {
     });
    }
 
-  const roLeft = new ResizeObserver(() => leftMap.resize());
-  const roRight = new ResizeObserver(() => rightMap.resize());
+  const resizeMap = (map) => {
+    requestAnimationFrame(() => {
+      map.resize();
+      map.triggerRepaint?.();
+    });
+  };
+
+  const roLeft = new ResizeObserver(() => resizeMap(leftMap));
+  const roRight = new ResizeObserver(() => resizeMap(rightMap));
 
   if (leftMapContainerRef.current) roLeft.observe(leftMapContainerRef.current);
   if (rightMapContainerRef.current) roRight.observe(rightMapContainerRef.current);
@@ -938,20 +1245,32 @@ const DualMaps = (props) => {
   // Also force a resize when the media query flips
   const mq = window.matchMedia('(max-width: 900px)');
   const onChange = () => {
-    leftMap.resize();
-    rightMap.resize();
+    resizeMap(leftMap);
+    resizeMap(rightMap);
   };
-  mq.addEventListener('change', onChange);
+
+  if (mq.addEventListener) {
+    mq.addEventListener('change', onChange);
+  } else {
+    mq.addListener(onChange);
+  }
 
   return () => {
     roLeft.disconnect();
     roRight.disconnect();
-    mq.removeEventListener('change', onChange);
+
+    if (mq.removeEventListener) {
+      mq.removeEventListener('change', onChange);
+    } else {
+      mq.removeListener(onChange);
+    }
   };
 }, [leftMap, rightMap]);
 
   return (
     <Wrap>
+      <MapStyleToggle />
+
       <StyledMapContainer ref={leftMapContainerRef}>
         {Object.values(state.layers).map((layer) => (
           <Layer key={layer.name} layer={layer} />
@@ -972,6 +1291,10 @@ const DualMaps = (props) => {
           left={false}
         />}
         {isMapReady &&
+          state.leftVisualisations &&
+          state.rightVisualisations &&
+          Object.keys(state.leftVisualisations).length > 0 &&
+          Object.keys(state.rightVisualisations).length > 0 &&
           (state.leftVisualisations[Object.keys(state.leftVisualisations)[0]]
             .data.length === 0 &&
           state.rightVisualisations[Object.keys(state.rightVisualisations)[0]]

--- a/packages/vis-core/src/Components/MapLayout/Map.jsx
+++ b/packages/vis-core/src/Components/MapLayout/Map.jsx
@@ -28,6 +28,7 @@ import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import { RectangleMode } from "@ookla/mapbox-gl-draw-rectangle";
 import debounce from "lodash.debounce";
 import { mapKeys, uniq } from "lodash";
+import MapStyleToggle from "./MapStyleToggle";
 
 const StyledMapContainer = styled.div`
   width: 100%;
@@ -36,6 +37,16 @@ const StyledMapContainer = styled.div`
    height: auto;             /* let content dictate height */
   }
 `;
+
+/**
+ * Safely get a source id from a MapLibre style layer.
+ *
+ * @param {Object} layer - MapLibre style layer definition.
+ * @returns {string|null} The source id if present, otherwise null.
+ */
+function getLayerSourceId(layer) {
+  return typeof layer?.source === "string" ? layer.source : null;
+}
 
 /**
  * When we add spider layers to the map, these are hoverable as they are 
@@ -80,14 +91,17 @@ function resolveBaseLayerIdFromSpiderLayerId(layerId) {
  */
 const Map = (props) => {
   const mapContainerRef = useRef(null);
+  const appliedMapStyleRef = useRef(null);
+  const hasDispatchedInitialBaseSourceIdsRef = useRef(false);
+
   const { state, dispatch } = useMapContext();
   const { mapStyle, mapCentre, mapZoom } = state;
-  const { map, isMapReady } = useMap(mapContainerRef, mapStyle, mapCentre, mapZoom, props.extraCopyrightText);
+  const { map, isMapReady, knownBaseSourceIds } = useMap(mapContainerRef, mapStyle, mapCentre, mapZoom, props.extraCopyrightText);
   const { dispatch: filterDispatch } = useFilterContext();
   const popups = {};
   const listenerCallbackRef = useRef({});
   const hoverIdRef = useRef({});
-  const sidebarIsOpen = props.sidebarIsOpen
+  const sidebarIsOpen = props.sidebarIsOpen;
   
   /**
    * Generates HTML for metadata section of tooltips
@@ -128,6 +142,24 @@ const Map = (props) => {
 
   const lastViewportSignatureRef = useRef({});
 
+  /**
+   * Push the initial base source ids captured by useMap into context state.
+   */
+  useEffect(() => {
+    if (!map || !knownBaseSourceIds?.current) return;
+    if (hasDispatchedInitialBaseSourceIdsRef.current) return;
+
+    const ids = Array.from(knownBaseSourceIds.current);
+
+    dispatch({
+      type: actionTypes.SET_BASE_SOURCE_IDS,
+      payload: ids,
+    });
+
+    hasDispatchedInitialBaseSourceIdsRef.current = true;
+
+  }, [map, knownBaseSourceIds, dispatch]);
+
   // Single feature picker for map clicks
   const pickFeatureAtPoint = useCallback(
     (point) => {
@@ -158,6 +190,104 @@ const Map = (props) => {
     },
     [map, memoizedFilters, state.layers]
   );
+
+  /**
+   * Handles map style switching while preserving custom app sources and layers.
+   *
+   * Uses transformStyle to merge the existing custom layers/sources from the
+   * previous style into the next basemap style.
+   */
+  useEffect(() => {
+    if (!map || !state.mapStyle) return;
+
+    const nextMapStyle =
+      typeof state.mapStyle === "function" ? state.mapStyle() : state.mapStyle;
+
+    if (appliedMapStyleRef.current === null) {
+      appliedMapStyleRef.current = nextMapStyle;
+      return;
+    }
+
+    if (appliedMapStyleRef.current === nextMapStyle) return;
+
+    appliedMapStyleRef.current = nextMapStyle;
+
+    map.setStyle(nextMapStyle, {
+      diff: true,
+      transformStyle: (previousStyle, nextStyle) => {
+        const previousBaseSourceIds =
+          knownBaseSourceIds?.current ??
+          new Set(state.baseSourceIds ?? []);
+
+        /**
+         * Custom sources are anything in the current/previous style that was
+         * NOT part of the previous basemap.
+         */
+        const customSourceEntries = Object.entries(
+          previousStyle.sources ?? {}
+        ).filter(([sourceId]) => !previousBaseSourceIds.has(sourceId));
+
+        const customSources = Object.fromEntries(customSourceEntries);
+        const customSourceIds = new Set(
+          customSourceEntries.map(([sourceId]) => sourceId)
+        );
+
+        /**
+         * Custom layers are layers attached to custom sources.
+         */
+        const customLayers = (previousStyle.layers ?? []).filter((layer) => {
+          const sourceId = getLayerSourceId(layer);
+          if (!sourceId) return false;
+
+          return (
+            customSourceIds.has(sourceId) ||
+            !previousBaseSourceIds.has(sourceId)
+          );
+        });
+
+        /**
+         * The incoming style is now the new basemap. Store its source ids as
+         * the latest known base source ids.
+         */
+        const nextBaseSourceIds = new Set(
+          Object.keys(nextStyle.sources ?? {})
+        );
+
+        knownBaseSourceIds.current = nextBaseSourceIds;
+
+        dispatch({
+          type: actionTypes.SET_BASE_SOURCE_IDS,
+          payload: Array.from(nextBaseSourceIds),
+        });
+
+        /**
+         * Avoid duplicate layer IDs if the incoming basemap has any layer with
+         * the same ID as one of our custom layers.
+         */
+        const nextLayerIds = new Set(
+          (nextStyle.layers ?? []).map((layer) => layer.id)
+        );
+
+        const safeCustomLayers = customLayers.filter(
+          (layer) => !nextLayerIds.has(layer.id)
+        );
+
+        const mergedStyle = {
+          ...nextStyle,
+          sources: {
+            ...(nextStyle.sources ?? {}),
+            ...customSources,
+          },
+          layers: [
+            ...(nextStyle.layers ?? []),
+            ...safeCustomLayers,
+          ],
+        };
+
+        return mergedStyle;
+      },
+    });
+  }, [map, state.mapStyle, state.baseSourceIds, knownBaseSourceIds, dispatch,]);
 
   // **Draw control logic
   useEffect(() => {
@@ -239,12 +369,12 @@ const Map = (props) => {
     });
 
     map.addControl(drawInstance);
-    dispatch(
-      { type: 'SET_DRAW_INSTANCE', payload: drawInstance }
-    );
-    
-  }, [map]); 
 
+    dispatch({
+      type: actionTypes.SET_DRAW_INSTANCE,
+      payload: drawInstance,
+    });
+  }, [map, dispatch]);
 
   /**
    * Handles hover events on the map and displays a single popup with information about all hovered features.
@@ -508,7 +638,7 @@ const Map = (props) => {
       let descriptions = [];
       // Track API requests and how they map back to description indexes so we can merge results precisely
       // NB if it's a spider layer, we resolve to the base layer to get custom tooltip metadata.
-  const apiRequests = [];
+      const apiRequests = [];
       const requestIndexByDescriptionIndex = {};
 
       filteredFeatures.forEach((feature) => {
@@ -817,7 +947,7 @@ const Map = (props) => {
       const mapZoomLevel = map.getZoom();
       
       dispatch({
-        type: "STORE_CURRENT_ZOOM",
+        type: actionTypes.STORE_CURRENT_ZOOM,
         payload: mapZoomLevel,
       });
 
@@ -869,7 +999,7 @@ const Map = (props) => {
         }
       }
     },
-    [map]
+    [map, dispatch]
   );
   
   
@@ -919,9 +1049,9 @@ const Map = (props) => {
           state.layers[layerId].shouldHaveTooltipOnClick
         ) {
           const { clickCallback, zoomHandler } =
-            listenerCallbackRef.current[layerId];
+            listenerCallbackRef.current[layerId] || {};
           if (clickCallback) {map.off("click", clickCallback)};
-          map.off('zoomend', zoomHandler);
+          if (zoomHandler) {map.off('zoomend', zoomHandler);}
 
           // Clean up hover info
           if (hoverInfoRef.current[layerId]) {
@@ -935,11 +1065,11 @@ const Map = (props) => {
         }
         if (state.layers[layerId].shouldHaveLabel) {
           const zoomHandler = listenerCallbackRef.current[layerId]?.zoomHandler;
-          map.off('zoomend', zoomHandler);
+          if (zoomHandler) {map.off('zoomend', zoomHandler);}
         }
       });
     };
-  }, [map, handleLayerLeave, state.layers, state.visualisations]);
+  }, [map, handleLayerLeave, state.layers, state.visualisations, handleZoom]);
 
   /**
    * Handles map click events and dispatches actions based on the clicked feature.
@@ -1131,7 +1261,7 @@ const Map = (props) => {
       map.off('click', onTap);
       map.off('touchend', onTap);
     };
-  }, [map, handleMapHover, handleMapClick, state.layers, memoizedFilters]);
+  }, [map, handleMapHover, handleMapClick, state.layers, memoizedFilters, pickFeatureAtPoint]);
 
 
   // Fallback for touch devices that do support hover
@@ -1158,12 +1288,14 @@ const Map = (props) => {
   // Run once to set the state of the map
   useEffect(() => {
     if (isMapReady) {
+      window.__debugMap = map;
+
       dispatch({
         type: "SET_MAP",
         payload: { map },
       });
     }
-  }, [isMapReady]);
+  }, [isMapReady, map, dispatch]);
 
   // Keep `state.currentZoom` in sync with the actual map zoom.
   // This is used by DynamicLegend and useLayerZoomMessage. Previously it was
@@ -1193,7 +1325,7 @@ const Map = (props) => {
 
   // **Handle map clicks (for map filters)**
   useEffect(() => {
-    if (isMapReady & state.filters.length > 0) {
+    if (isMapReady && state.filters.length > 0) {
       const hasMapFilter = state.filters.some(
         (filter) => filter.type === "map"
       );
@@ -1207,7 +1339,7 @@ const Map = (props) => {
         map.off("click", handleMapClick);
       }
     };
-  }, [isMapReady, map, handleMapClick]);
+  }, [isMapReady, map, handleMapClick, state.filters]);
 
   // **Capture viewport (bbox) into FilterContext + query params**
   useEffect(() => {
@@ -1336,6 +1468,7 @@ const Map = (props) => {
   // **Apply layer filters**
   useEffect(() => {
     if (!map) return;
+    if (!state.visualisedFeatureIds) return;
 
     Object.keys(state.layers).forEach((layerId) => {
       if (map.getLayer(layerId)) {
@@ -1356,7 +1489,7 @@ const Map = (props) => {
         }
       }
     });
-  }, [map, state.visualisedFeatureIds]);
+  }, [map, state.layers, state.visualisedFeatureIds]);
 
   // **Pan and centre map**
   useEffect(() => {
@@ -1412,14 +1545,16 @@ const Map = (props) => {
   
   return (
     <StyledMapContainer ref={mapContainerRef}>
+      <MapStyleToggle />
+
       {Object.values(state.layers).map((layer) => (
-      <>
+      <React.Fragment key={layer.name}>
         <Layer key={layer.name} layer={layer} />
         { /* Create a sibling 'spider' layer for all point layers, to deal with overlaps */}
         {layer.type === 'tile' && layer.geometryType === 'point' && Boolean(layer.spiderfyOverlappingPoints) && (
           <SpiderLayer key={`${layer.name}_spider`} baseLayerId={layer.name} />
         )}
-      </>
+      </React.Fragment>
       ))}
       {state.visualisations && <VisualisationManager
         visualisationConfigs={state.visualisations}

--- a/packages/vis-core/src/Components/MapLayout/MapLayout.css
+++ b/packages/vis-core/src/Components/MapLayout/MapLayout.css
@@ -130,6 +130,37 @@
 
   .map-stack { display: flex; flex-direction: column; }
 
+  .map-style-toggle {
+    position: absolute;
+    left: 6px;
+    bottom: 8px;
+    z-index: 3;
+  }
+
+  .map-style-toggle__button {
+    width: 23px;
+    height: 25px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    line-height: 1;
+    color: #000;
+    background: #fff;
+    border: 0;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .map-style-toggle__button:hover {
+    background: #f0f0f0;
+  }
+
+  .map-style-toggle__button:focus {
+    outline: 2px solid #1978c8;
+    outline-offset: -2px;
+  }
+
   @media (max-width: 900px) {
     .maplibregl-ctrl-bottom-right > .maplibregl-ctrl-attrib.app-attrib { display:none!important; }
 

--- a/packages/vis-core/src/Components/MapLayout/MapStyleToggle.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapStyleToggle.jsx
@@ -1,0 +1,78 @@
+import React, { useMemo } from "react";
+import { useMapContext } from "hooks";
+import { mapStyles } from "defaults";
+import "./MapLayout.css";
+
+const LIGHT_STYLE = "geoapifyPositron";
+const DARK_STYLE = "geoapifyDarkMatter";
+
+/**
+ * Resolves the current map style key from the active map style value.
+ *
+ * If no map style is provided, the light style is used as the default.
+ *
+ * @param {string} mapStyle - The currently active map style value.
+ * @returns {string} The matching map style key.
+ */
+const resolveCurrentStyleKey = (mapStyle) => {
+  if (!mapStyle) return LIGHT_STYLE;
+
+  const entries = Object.entries(mapStyles);
+  const matched = entries.find(([key, value]) => {
+    const resolved = typeof value === "function" ? value() : value;
+    return resolved === mapStyle;
+  });
+
+  return matched?.[0] || LIGHT_STYLE;
+};
+
+/**
+ * MapStyleToggle component for switching between light and dark basemaps.
+ *
+ * Uses the current map style from context to determine which basemap is active,
+ * then dispatches an action to switch to the opposite style when clicked.
+ *
+ * @returns {JSX.Element} A map control button for toggling map style.
+ */
+const MapStyleToggle = () => {
+  const { state, dispatch } = useMapContext();
+
+  const currentStyleKey = useMemo(
+    () => resolveCurrentStyleKey(state.mapStyle),
+    [state.mapStyle]
+  );
+
+  const isDark = currentStyleKey === DARK_STYLE;
+
+  /**
+   * Toggles the map style between light and dark basemaps.
+   */
+  const handleToggle = () => {
+    const nextStyleKey = isDark ? LIGHT_STYLE : DARK_STYLE;
+    const nextStyle =
+      typeof mapStyles[nextStyleKey] === "function"
+        ? mapStyles[nextStyleKey]()
+        : mapStyles[nextStyleKey];
+
+    dispatch({
+      type: "UPDATE_MAP_STYLE",
+      payload: nextStyle,
+    });
+  };
+
+  return (
+    <div className="map-style-toggle maplibregl-ctrl maplibregl-ctrl-group">
+      <button
+        className="maplibregl-ctrl-icon map-style-toggle__button"
+        type="button"
+        title={isDark ? "Switch to light basemap" : "Switch to dark basemap"}
+        aria-label={isDark ? "Switch to light basemap" : "Switch to dark basemap"}
+        onClick={handleToggle}
+      >
+        {isDark ? "☀" : "🌙"}
+      </button>
+    </div>
+  );
+};
+
+export default React.memo(MapStyleToggle);

--- a/packages/vis-core/src/contexts/MapContext.jsx
+++ b/packages/vis-core/src/contexts/MapContext.jsx
@@ -100,6 +100,7 @@ export const MapProvider = ({ children }) => {
     mapZoom: pageContext.customMapZoom
       ? parseFloat(pageContext.customMapZoom)
       : defaultMapZoom,
+    baseSourceIds: [],
     layers: {},
     visualisations: {},
     leftVisualisations: {},
@@ -123,8 +124,7 @@ export const MapProvider = ({ children }) => {
       ? parseFloat(pageContext.customMapZoom)
       : defaultMapZoom,
   };
-
-
+  
   const [state, dispatch] = useReducer(mapReducer, initialState);
 
   const contextValue = React.useMemo(() => {

--- a/packages/vis-core/src/defaults.js
+++ b/packages/vis-core/src/defaults.js
@@ -1,6 +1,7 @@
 import { getMapApiToken } from './runtime'; 
 export const mapStyles = {
   geoapifyPositron: () => `https://maps.geoapify.com/v1/styles/positron/style.json?apiKey=${getMapApiToken()}`,
+  geoapifyDarkMatter: () => `https://maps.geoapify.com/v1/styles/dark-matter/style.json?apiKey=${getMapApiToken()}`,
 
   osMapsApiRaster: () => ({
     version: 8,

--- a/packages/vis-core/src/hooks/useDualMaps.jsx
+++ b/packages/vis-core/src/hooks/useDualMaps.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import maplibregl from "maplibre-gl";
 import { syncMaps } from "utils";
 import { defaultMapStyle, defaultMapCentre, defaultMapZoom } from "defaults";
@@ -11,7 +11,8 @@ import { defaultMapStyle, defaultMapCentre, defaultMapZoom } from "defaults";
  * @param {string} mapStyle - A custom map style to be used for both maps.
  * @param {Array<number>} mapCentre - The initial map center coordinates [longitude, latitude].
  * @param {number} mapZoom - The initial map zoom level.
- * @returns {Object} An object containing the left and right map instances, map style loaded state, map loaded state, and map ready state.
+ * @param {string} extraCopyrightText - Extra copyright text for attribution.
+ * @returns {Object} An object containing the left and right map instances, map loaded states, and base source refs.
  */
 export const useDualMaps = (
   leftMapContainerRef,
@@ -27,12 +28,96 @@ export const useDualMaps = (
   const [isMapLoaded, setIsMapLoaded] = useState(false);
   const isMapReady = isMapLoaded && isMapStyleLoaded;
 
+  const leftKnownBaseSourceIds = useRef(null);
+  const rightKnownBaseSourceIds = useRef(null);
+  const knownBaseSourceIds = useRef({
+    left: null,
+    right: null,
+  });
+
   useEffect(() => {
+    let leftMapInstance = null;
+    let rightMapInstance = null;
+    let isCleanedUp = false;
+
+    let leftLoaded = false;
+    let rightLoaded = false;
+    let leftStyleLoaded = false;
+    let rightStyleLoaded = false;
+
+    let leftContainerResizeObserver = null;
+    let rightContainerResizeObserver = null;
+
+    /**
+     * Safely resize/repaint a map.
+     */
+    const safeResizeAndRepaint = (mapInstance) => {
+      if (isCleanedUp || !mapInstance) return;
+
+      try {
+        mapInstance.resize();
+        mapInstance.triggerRepaint?.();
+      } catch {
+        // Ignore resize/repaint calls after map removal.
+      }
+    };
+
+    /**
+     * Capture the initial base source IDs for one side.
+     * 
+     * These are used later during runtime style switching so the application can
+     * preserve custom sources/layers while replacing only the basemap style.
+     */
+    const captureInitialBaseSourceIds = (side, mapInstance) => {
+      if (!mapInstance) return;
+
+      if (side === "left" && leftKnownBaseSourceIds.current) return;
+      if (side === "right" && rightKnownBaseSourceIds.current) return;
+
+      const style = mapInstance.getStyle();
+      const sourceIds = Object.keys(style?.sources ?? {});
+      const sourceIdSet = new Set(sourceIds);
+
+      if (side === "left") {
+        leftKnownBaseSourceIds.current = sourceIdSet;
+      } else {
+        rightKnownBaseSourceIds.current = sourceIdSet;
+      }
+
+      knownBaseSourceIds.current[side] = sourceIdSet;
+    };
+
+    /**
+     * Expose the map instances only when both maps have loaded.
+     */
+    const maybeExposeMaps = () => {
+      if (isCleanedUp) return;
+
+      if (leftStyleLoaded && rightStyleLoaded) {
+        setIsMapStyleLoaded(true);
+      }
+
+      if (leftLoaded && rightLoaded) {
+        setIsMapLoaded(true);
+        setLeftMap(leftMapInstance);
+        setRightMap(rightMapInstance);
+      }
+    };
+
     /**
      * Initializes the two MapLibre map instances.
      */
-    const initializeDualMap = () => {      
-      const styleValue = typeof mapStyle === "function" ? mapStyle() : (mapStyle || defaultMapStyle);
+    const initializeDualMap = () => {
+      const leftContainer = leftMapContainerRef.current;
+      const rightContainer = rightMapContainerRef.current;
+
+      if (!leftContainer || !rightContainer) return;
+
+      const styleValue = typeof mapStyle === "function" ? mapStyle() : mapStyle ||
+            (typeof defaultMapStyle === "function"
+              ? defaultMapStyle()
+              : defaultMapStyle);
+
       const commonOptions = {
         style: styleValue,
         center: mapCentre || defaultMapCentre,
@@ -55,35 +140,48 @@ export const useDualMaps = (
               url: new Request(url).url
             };
           }
+          return { url };
         },
       };
 
-      const leftMapInstance = new maplibregl.Map({
-        container: leftMapContainerRef.current,
+      leftMapInstance = new maplibregl.Map({
+        container: leftContainer,
+        ...commonOptions,
+      });
+
+      rightMapInstance = new maplibregl.Map({
+        container: rightContainer,
         ...commonOptions,
       });
       
       // Add event listeners after map creation
-      leftMapInstance.on("style.load", () => setIsMapStyleLoaded(true));
-      leftMapInstance.on("load", () => {
-        setIsMapLoaded(true);
+      leftMapInstance.on("style.load", () => {
+        leftStyleLoaded = true;
+        captureInitialBaseSourceIds("left", leftMapInstance);
+        maybeExposeMaps();
       });
+
+      leftMapInstance.on("load", () => {
+        leftLoaded = true;
+        maybeExposeMaps();
+      });
+
       leftMapInstance.addControl(
         new maplibregl.NavigationControl(),
         "bottom-left"
       );
-      leftMapInstance.resize();
 
-      const rightMapInstance = new maplibregl.Map({
-        container: rightMapContainerRef.current,
-        ...commonOptions,
+      rightMapInstance.on("style.load", () => {
+        rightStyleLoaded = true;
+        captureInitialBaseSourceIds("right", rightMapInstance);
+        maybeExposeMaps();
       });
-      
-      // Add event listeners after map creation
-      rightMapInstance.on("style.load", () => setIsMapStyleLoaded(true));
+
       rightMapInstance.on("load", () => {
-        setIsMapLoaded(true);
+        rightLoaded = true;
+        maybeExposeMaps();
       });
+
       rightMapInstance.addControl(
         new maplibregl.NavigationControl(),
         "bottom-left"
@@ -95,9 +193,41 @@ export const useDualMaps = (
         }),
         "bottom-right"
       );
-      rightMapInstance.resize();
 
-      const isMobile = window.matchMedia('(max-width: 900px)').matches;
+      /**
+       * Resize observers.
+       *
+       * DualMaps.jsx also has resize handling, but doing it here too makes the
+       * hook more resilient during first load and layout changes.
+       */
+      if ("ResizeObserver" in window) {
+        leftContainerResizeObserver = new ResizeObserver(() => {
+          requestAnimationFrame(() => {
+            safeResizeAndRepaint(leftMapInstance);
+          });
+        });
+
+        rightContainerResizeObserver = new ResizeObserver(() => {
+          requestAnimationFrame(() => {
+            safeResizeAndRepaint(rightMapInstance);
+          });
+        });
+
+        leftContainerResizeObserver.observe(leftContainer);
+        rightContainerResizeObserver.observe(rightContainer);
+      }
+
+      /**
+       * Initial resize.
+       */
+      safeResizeAndRepaint(leftMapInstance);
+      safeResizeAndRepaint(rightMapInstance);
+
+      /**
+       * Mobile interaction adjustment.
+       */
+      const isMobile = window.matchMedia("(max-width: 900px)").matches;
+
       if (isMobile) {
         [leftMapInstance, rightMapInstance].forEach(map => {
           map.scrollZoom.disable();      // prevent single-finger zoom
@@ -114,26 +244,42 @@ export const useDualMaps = (
 
       // Synchronize the two maps
       syncMaps(leftMapInstance, rightMapInstance);
-
-      setLeftMap(leftMapInstance);
-      setRightMap(rightMapInstance);
     };
 
-    if (!leftMap && !rightMap) {
-      initializeDualMap();
-    }
+    initializeDualMap();
 
     return () => {
-      if (leftMap) {
-        leftMap.remove();
-        setLeftMap(null);
+      isCleanedUp = true;
+
+      if (leftContainerResizeObserver) {
+        leftContainerResizeObserver.disconnect();
       }
-      if (rightMap) {
-        rightMap.remove();
-        setRightMap(null);
+
+      if (rightContainerResizeObserver) {
+        rightContainerResizeObserver.disconnect();
       }
+
+      if (leftMapInstance) {
+        leftMapInstance.remove();
+        leftMapInstance = null;
+      }
+
+      if (rightMapInstance) {
+        rightMapInstance.remove();
+        rightMapInstance = null;
+      }
+
+      setLeftMap(null);
+      setRightMap(null);
       setIsMapLoaded(false);
       setIsMapStyleLoaded(false);
+
+      leftKnownBaseSourceIds.current = null;
+      rightKnownBaseSourceIds.current = null;
+      knownBaseSourceIds.current = {
+        left: null,
+        right: null,
+      };
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -160,6 +306,6 @@ export const useDualMaps = (
   }, [leftMap, rightMap, mapZoom]);
 
 
-
-  return { leftMap, rightMap, isMapStyleLoaded, isMapLoaded, isMapReady };
+  
+  return { leftMap, rightMap, isMapStyleLoaded, isMapLoaded, isMapReady, leftKnownBaseSourceIds, rightKnownBaseSourceIds, knownBaseSourceIds, };
 };

--- a/packages/vis-core/src/hooks/useMap.jsx
+++ b/packages/vis-core/src/hooks/useMap.jsx
@@ -22,10 +22,27 @@ export const useMap = (mapContainerRef, mapStyle, mapCentre, mapZoom, extraCopyr
   const [isMapLoaded, setIsMapLoaded] = useState(false);
   const isMapReady = isMapLoaded && isMapStyleLoaded;
   const belowBarRef = useRef(null);
+  const knownBaseSourceIds = useRef(null);
 
   useEffect(() => {
     // Will be assigned after Map construction; transformRequest can still close over it.
     let mapInstance = null;
+
+    /**
+     * Captures the initial basemap source IDs once.
+     * 
+     * These are used later during runtime style switching so the application can
+     * preserve custom sources/layers while replacing only the basemap style.
+     */
+    const captureInitialBaseSourceIds = () => {
+      if (!mapInstance || knownBaseSourceIds.current) return;
+
+      const style = mapInstance.getStyle();
+      const sourceIds = Object.keys(style?.sources ?? {});
+
+      knownBaseSourceIds.current = new Set(sourceIds);
+    };
+
     /**
      * Initializes the MapLibre map instance.
      */
@@ -107,9 +124,18 @@ export const useMap = (mapContainerRef, mapStyle, mapCentre, mapZoom, extraCopyr
       });
 
       // Add event listeners after map creation
-      mapInstance.on("style.load", () => setIsMapStyleLoaded(true));
+      mapInstance.on("style.load", () => {
+        setIsMapStyleLoaded(true);
+
+        // Capture initial basemap sources once, before app layers are added.
+        captureInitialBaseSourceIds();
+      });
+
       mapInstance.on("load", () => {
         setIsMapLoaded(true);
+
+        // Expose map after initial load.
+        setMap(mapInstance);
       });
 
       const nav = new maplibregl.NavigationControl({ showZoom: true, showCompass: true });
@@ -178,10 +204,28 @@ export const useMap = (mapContainerRef, mapStyle, mapCentre, mapZoom, extraCopyr
       window.addEventListener('resize', updateNavOffset);
       window.addEventListener('orientationchange', updateNavOffset);
 
+      let containerResizeObserver;
+
+      if ("ResizeObserver" in window && container) {
+        containerResizeObserver = new ResizeObserver(() => {
+          if (!mapInstance) return;
+
+          requestAnimationFrame(() => {
+            mapInstance.resize();
+            mapInstance.triggerRepaint?.();
+          });
+        });
+
+        containerResizeObserver.observe(container);
+      }
+
       // keep refs for cleanup
       mapInstance.__nav = nav;
       mapInstance.__navMql = mql;
       mapInstance.__navOnChange = onMqChange;
+      mapInstance.__navResizeObserver = ro;
+      mapInstance.__navUpdateOffset = updateNavOffset;
+      mapInstance.__containerResizeObserver = containerResizeObserver;
 
       mapInstance.resize();
 
@@ -197,14 +241,6 @@ export const useMap = (mapContainerRef, mapStyle, mapCentre, mapZoom, extraCopyr
         mapInstance.touchZoomRotate.enable();
         mapInstance.touchZoomRotate.disableRotation(); // optional
       }
-
-      if (mql?.removeEventListener) mql.removeEventListener('change', onMqChange);
-
-      if (ro) ro.disconnect();
-      window.removeEventListener('resize', updateNavOffset);
-      window.removeEventListener('orientationchange', updateNavOffset);
-
-      setMap(mapInstance);
     };
 
     initializeMap();
@@ -212,10 +248,34 @@ export const useMap = (mapContainerRef, mapStyle, mapCentre, mapZoom, extraCopyr
     return () => {
       if (mapInstance) {
         console.log("Cleaning up map instance");
+
+        const mql = mapInstance.__navMql;
+        const onMqChange = mapInstance.__navOnChange;
+        const updateNavOffset = mapInstance.__navUpdateOffset;
+        const ro = mapInstance.__navResizeObserver;
+        const containerResizeObserver = mapInstance.__containerResizeObserver;
+
+        if (mql && onMqChange) {
+          if (mql.removeEventListener) {
+            mql.removeEventListener("change", onMqChange);
+          } else if (mql.removeListener) {
+            mql.removeListener(onMqChange);
+          }
+        }
+
+        if (ro) ro.disconnect();
+        if (containerResizeObserver) containerResizeObserver.disconnect();
+
+        if (updateNavOffset) {
+          window.removeEventListener('resize', updateNavOffset);
+          window.removeEventListener('orientationchange', updateNavOffset);
+        }
+
         mapInstance.remove();
         setMap(null);
         setIsMapLoaded(false);
         setIsMapStyleLoaded(false);
+        knownBaseSourceIds.current = null;
       }
     };
   }, []);
@@ -234,5 +294,11 @@ export const useMap = (mapContainerRef, mapStyle, mapCentre, mapZoom, extraCopyr
     }
   }, [map, mapZoom]);
 
-  return { map, isMapStyleLoaded, isMapLoaded, isMapReady };
+  return {
+    map,
+    isMapStyleLoaded,
+    isMapLoaded,
+    isMapReady,
+    knownBaseSourceIds,
+  };
 };

--- a/packages/vis-core/src/reducers/mapReducer.js
+++ b/packages/vis-core/src/reducers/mapReducer.js
@@ -139,6 +139,7 @@ export const actionTypes = {
   UPDATE_MAP_CENTRE: "UPDATE_MAP_CENTRE",
   UPDATE_MAP_ZOOM: "UPDATE_MAP_ZOOM",
   UPDATE_MAP_STYLE: "UPDATE_MAP_STYLE",
+  SET_BASE_SOURCE_IDS: "SET_BASE_SOURCE_IDS",
   INITIALISE_SIDEBAR: "INITIALISE_SIDEBAR",
   SET_PAGE_INFO: "SET_PAGE_INFO",
   SET_MAP: "SET_MAP",
@@ -216,6 +217,15 @@ const mergeCategoricalLegendEntries = (currentCache = {}, nextEntries = {}) => {
  */
 export const mapReducer = (state, action) => {
   switch (action.type) {
+    case actionTypes.SET_BASE_SOURCE_IDS: {
+      return {
+        ...state,
+        baseSourceIds: Array.isArray(action.payload)
+          ? action.payload
+          : Array.from(action.payload ?? []),
+      };
+    }
+
     case actionTypes.STORE_CURRENT_ZOOM: {
       return { ...state, currentZoom: action.payload }
     }
@@ -258,6 +268,7 @@ export const mapReducer = (state, action) => {
     case actionTypes.RESET_CONTEXT:
       return {
         ...state,
+        baseSourceIds: [],
         layers: {},
         colorSchemesByLayer: {},
         visualisations: {},


### PR DESCRIPTION
This PR adds support for switching between light and dark basemap styles at runtime  without requiring a page reload. A new dark Geoapify style is available alongside the existing light `geoapifyPositron` style, and a map control has been added to allow users to toggle between the two.

A plain `map.setStyle(newStyle)` removes sources and layers that are not present in the incoming style. This caused custom data layers such as CVT road network layers to disappear when switching from the light basemap to the dark basemap.

To solve this, the map now tracks the source IDs belonging to the active basemap. On style switch, anything in the previous style that is not part of the basemap is treated as custom application state and merged into the incoming style.The main correction was replacing plain `setStyle` behaviour with MapLibre’s `transformStyle `flow. 

# Changes

**Map.jsx -**
- Added runtime style switching using `map.setStyle(..., { diff: true, transformStyle })`.
- Added logic to identify basemap sources versus custom application sources/layers.
- Preserves custom data layers, hover/select layers, draw layers, and other runtime-added layers during basemap switches.
- Dispatches the initially captured basemap source IDs into map context state for later comparison

**useMap.jsx -**
Added `knownBaseSourceIds `tracking for the initial basemap.
Captures basemap source IDs before exposing the map instance to child components.
Added resize/repaint handling after map load/idle and on container resize to improve first-render stability.
Moved listener/observer cleanup into the React effect cleanup function 

**MapContext.jsx and mapReducer.js -**
- Added `baseSourceIds `to map state.
- Added `SET_BASE_SOURCE_IDS `action so the currently known basemap source IDs can be stored and reset with map context.

Similar functionality has been implemented in DualMaps.jsx and useDualMaps.jsx

- Closes #217 

Although, one thing to check is how it performs when the page loads initially, as there was an issue where the custom layer was not showing up when the page first loads but only did when the page was refreshed. This looks like browser related when tested locally but might behave differently in production. Hence, additional resize/repaint handling is added to improve first-load behaviour. 

### Acceptance Criteria

* [x] **New style added:** A new dark base map style (e.g., `geoapifyDarkMatter`) is defined in the `vis-core` defaults.
* [x] **Configurable default:** Consuming applications can select the initial default base map via their application configuration (this is partially supported already via `appContext.mapStyle`).
* [x] **Runtime toggle:** A new button is visible on the map that allows the user to toggle between the Light and Dark base maps.
* [x] **Native styling:** The new toggle button perfectly matches the existing MapLibre zoom and pan controls (using MapLibre's native CSS classes). Movement aligned with these selectors.
* [x] **Seamless switching:** Clicking the toggle updates the map style immediately without requiring a page reload, and existing data layers remain visible.


<img width="1425" height="952" alt="image" src="https://github.com/user-attachments/assets/04be7898-cc7c-4b55-b1e8-3e4417ffc299" />
