### PR TITLE
Handle wrapped API response format 

### DIFF
--- a/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
+++ b/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
@@ -92,7 +92,7 @@ const toSimpleParamsMap = (paramsMap = {}) => {
  * @param {Array|Object} response - The raw API response.
  * @returns {Array} - The unwrapped data array, or the original response if not a recognised envelope.
  */
-const unwrapApiResponse = (response) => {
+export const unwrapApiResponse = (response) => {
   if (
     response !== null &&
     typeof response === 'object' &&

--- a/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
+++ b/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
@@ -86,6 +86,25 @@ const toSimpleParamsMap = (paramsMap = {}) => {
 };
 
 /**
+ * Unwraps a `{ data, metadata }` API response envelope if present.
+ * Returns the inner `data` array directly. Plain array responses are passed through as-is.
+ *
+ * @param {Array|Object} response - The raw API response.
+ * @returns {Array} - The unwrapped data array, or the original response if not a recognised envelope.
+ */
+const unwrapApiResponse = (response) => {
+  if (
+    response !== null &&
+    typeof response === 'object' &&
+    !Array.isArray(response) &&
+    Array.isArray(response.data)
+  ) {
+    return response.data;
+  }
+  return response;
+};
+
+/**
  * Helper: Checks whether all required params in a map have a non-null/undefined value.
  *
  * @param {Object<string, {value:any, required?:boolean}>} paramsMap - Map of param definitions.
@@ -416,12 +435,14 @@ export const useFetchVisualisationData = (
         const currentSignal = abortControllerRef.current.signal;
 
         try {
-          const responseData = await api.baseService.get(path, {
+          const rawResponse = await api.baseService.get(path, {
             pathParams: pathParamsForApi,
             queryParams: queryParamsForApi,
             skipAuth: !requiresAuth,
             signal: currentSignal,
           });
+
+          const responseData = unwrapApiResponse(rawResponse);
 
           // Only set data if request wasn't aborted
           if (currentSignal.aborted) {

--- a/packages/vis-core/src/hooks/useFetchVisualisationData.test.jsx
+++ b/packages/vis-core/src/hooks/useFetchVisualisationData.test.jsx
@@ -1,0 +1,17 @@
+import { unwrapApiResponse } from './useFetchVisualisationData';
+
+describe('unwrapApiResponse', () => {
+  it('passes a plain array through as-is', () => {
+    const input = [{ id: 1 }];
+    expect(unwrapApiResponse(input)).toEqual([{ id: 1 }]);
+  });
+
+  it('unwraps { data, metadata } envelope and returns the data array', () => {
+    const input = { data: [{ id: 1 }], metadata: {} };
+    expect(unwrapApiResponse(input)).toEqual([{ id: 1 }]);
+  });
+
+  it('passes through null as-is', () => {
+    expect(unwrapApiResponse(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
# Changes
Unwrap the envelope in `useFetchVisualisationData` before any data processing. Plain array responses from all other endpoints are unaffected.

The `/api/bronte/households/zone-data` endpoint returns a wrapped response shape `{ data: [...], metadata: {...} }` rather than a plain array, causing no features to be styled on the map as `useFetchVisualisationData` set `responseData` to the envelope object instead of the array.

<img width="1913" height="994" alt="image" src="https://github.com/user-attachments/assets/2746661a-4836-473c-93fb-a3bda6e663d2" />

- Closes #242 
