### PR TITLE
Support time-series array data in line charts

### DIFF
--- a/packages/vis-core/src/Components/Charts/ChartRenderer.jsx
+++ b/packages/vis-core/src/Components/Charts/ChartRenderer.jsx
@@ -266,6 +266,7 @@ const toTimeSeries = (data) =>
   (data || []).map((point) => ({
     label: String(point.year),
     value: point.value,
+    dmValue: point.dmValue ?? null,
   }));
 
 /**
@@ -598,6 +599,7 @@ const LineSeriesChart = ({ config, data, formatters }) => {
   );
   const height = config.height ?? DEFAULTS.DIMENSIONS.baseHeight;
   const stroke = config.lineColor || DEFAULTS.BRAND_COLOR;
+  const dmStroke = config.dmLineColor || "#999999";
   const formatter = (val) => {
     const n = Number(val);
     return Number.isFinite(n) ? formatNumber(n) : "";
@@ -609,6 +611,11 @@ const LineSeriesChart = ({ config, data, formatters }) => {
         items.map((i) => i.label)
       ),
     [config, items]
+  );
+
+  // Check if any point has a dmValue, so we know whether to render the second line
+  const hasDmValues = items.some(
+    (i) => i.dmValue !== null && i.dmValue !== undefined
   );
 
   return (
@@ -637,14 +644,32 @@ const LineSeriesChart = ({ config, data, formatters }) => {
           formatter={formatter}
           cursor={{ stroke: "#ccc", strokeDasharray: "3 3" }}
         />
+        {hasDmValues && (
+          <RLegend
+            wrapperStyle={{ fontSize: DEFAULTS.DIMENSIONS.tickFontSize }}
+          />
+        )}
         <RLine
           type="monotone"
           dataKey="value"
+          name={hasDmValues ? "DS" : (config.title || "Value")}
           stroke={stroke}
           strokeWidth={2}
           dot={false}
           activeDot={{ r: 4 }}
         />
+        {hasDmValues && (
+          <RLine
+            type="monotone"
+            dataKey="dmValue"
+            name="DM"
+            stroke={dmStroke}
+            strokeWidth={2}
+            strokeDasharray="4 4"
+            dot={false}
+            activeDot={{ r: 4 }}
+          />
+        )}
       </RLineChart>
     </ChartSection>
   );

--- a/packages/vis-core/src/Components/Charts/ChartRenderer.jsx
+++ b/packages/vis-core/src/Components/Charts/ChartRenderer.jsx
@@ -255,6 +255,20 @@ const toSeries = (config, data) =>
   }));
 
 /**
+ * Transforms a time-series array (e.g. [{year, value}, ...]) into chart items.
+ * Used for line charts plotting continuous data over time, as opposed to
+ * toSeries which handles a fixed set of category columns.
+ *
+ * @param {Array<{year: number|string, value: number}>} data - Array of time-series points
+ * @returns {Array} - Array of series objects with label and value
+ */
+const toTimeSeries = (data) =>
+  (data || []).map((point) => ({
+    label: String(point.year),
+    value: point.value,
+  }));
+
+/**
  * Renders a responsive bar chart using Recharts
  * @param {Object} props - Component props
  * @param {Object} props.config - Chart configuration object
@@ -578,7 +592,10 @@ const BarChartMultiple = ({
  * @returns {JSX.Element} - Line chart component with X/Y axes, grid, and tooltip
  */
 const LineSeriesChart = ({ config, data, formatters }) => {
-  const items = React.useMemo(() => toSeries(config, data), [config, data]);
+  const items = React.useMemo(
+    () => (Array.isArray(data) ? toTimeSeries(data) : toSeries(config, data)),
+    [config, data]
+  );
   const height = config.height ?? DEFAULTS.DIMENSIONS.baseHeight;
   const stroke = config.lineColor || DEFAULTS.BRAND_COLOR;
   const formatter = (val) => {
@@ -607,7 +624,7 @@ const LineSeriesChart = ({ config, data, formatters }) => {
           angle={DEFAULTS.DIMENSIONS.xAngle}
           textAnchor="end"
           height={xAxisHeight}
-          interval={0}
+          interval={Array.isArray(data) ? "preserveStartEnd" : 0}
           tick={{ fontSize: DEFAULTS.DIMENSIONS.tickFontSize }}
         />
         <RYAxis
@@ -625,7 +642,7 @@ const LineSeriesChart = ({ config, data, formatters }) => {
           dataKey="value"
           stroke={stroke}
           strokeWidth={2}
-          dot={{ r: 2 }}
+          dot={false}
           activeDot={{ r: 4 }}
         />
       </RLineChart>

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
@@ -508,6 +508,8 @@ export const CalloutCardVisualisation = ({
                         label: network,
                       }));
                       configs.xKey = "label";
+                    } else if (chart.type === "line") {
+                      chartData = chart.values;
                     } else {
                       // Data formatted for single bar
                       configs.columns = chart.values.map((obj) => ({


### PR DESCRIPTION
# Changes
Added support for rendering line charts from time-series array data (e.g. `[{year, value}, ...]`) in addition to the existing column-based chart data.

- Added `toTimeSeries` helper in `ChartRenderer.jsx` to transform an array of `{year, value}` points into chart items, separate from the existing `toSeries` which handles fixed category columns
- Updated `LineSeriesChart` to detect array-shaped data and branch to `toTimeSeries` instead of `toSeries`
- Changed X-axis tick `interval` to `preserveStartEnd` for array-shaped (time-series) data, avoiding all labels rendering when there are many data points; column-based charts retain `interval={0}` (unchanged)
- Changed line chart dots to hidden by default (`dot={false}`) for time-series data to reduce visual clutter with many points; `activeDot` still shows on hover
- Updated `CalloutCardVisualisation.jsx` to pass `chart.values` straight through for `chart.type === "line"`, rather than falling into the existing single-bar/ranking reshaping logic (which expected `name`/`columnValue` fields and previously produced no usable output for time-series points)
- Added a second `RLine` for DM comparison data (`dataKey="dmValue"`), rendered conditionally when DM values are present in the data, with a dashed stroke and legend to distinguish it from the primary DS line

# BEFORE
<img width="316" height="234" alt="image" src="https://github.com/user-attachments/assets/960f7829-7f0e-4207-be56-a68a085e38f1" />

# AFTER
<img width="318" height="255" alt="image" src="https://github.com/user-attachments/assets/2ee56f76-ee6b-4280-9044-2ed407cc1fb1" />
<img width="318" height="249" alt="image" src="https://github.com/user-attachments/assets/cc684bdd-2afe-4679-a88f-461bc81277ff" />

- Closes https://github.com/Transport-for-the-North/BRONTE-Visualisation-Framework/issues/180