### PR TITLE
Fix Math.min/max spread overflow and single-value bin collapse

### DIFF
--- a/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.utils.js
+++ b/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.utils.js
@@ -1,6 +1,10 @@
 import { forEach } from "lodash";
 import { convertStringToNumber, numberWithCommas, formatNumber } from "utils";
 
+// Module-scope, monomorphic reducers for min/max
+const minReducer = (min, v) => (v < min ? v : min);
+const maxReducer = (max, v) => (v > max ? v : max);
+
 /**
  * Interpolates widths for color stops based on width stops.
  *
@@ -445,13 +449,13 @@ export const extractDataValues = (data) => {
 export const getOutOfBandFlags = (data, numericEntries) => {
   const bandEdges = (numericEntries || []).filter(Number.isFinite);
   if (bandEdges.length < 2) return { belowMin: false, aboveMax: false };
-  const bandMin = Math.min(...bandEdges);
-  const bandMax = Math.max(...bandEdges);
+  const bandMin = bandEdges.reduce(minReducer, Infinity);
+  const bandMax = bandEdges.reduce(maxReducer, -Infinity);
   const values = extractDataValues(data);
   if (values.length === 0) return { belowMin: false, aboveMax: false };
   return {
-    belowMin: Math.min(...values) < bandMin,
-    aboveMax: Math.max(...values) > bandMax,
+    belowMin: values.reduce(minReducer, Infinity) < bandMin,
+    aboveMax: values.reduce(maxReducer, -Infinity) > bandMax,
   };
 };
 

--- a/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.utils.test.js
+++ b/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.utils.test.js
@@ -1,0 +1,17 @@
+import { getOutOfBandFlags } from './DynamicLegend.utils';
+
+describe('getOutOfBandFlags', () => {
+  it('does not throw a call stack size exceeded error for very large datasets', () => {
+    // Create an array with > 150,000 items to trigger the spread operator stack size limit
+    // if Math.max(...values) or similar is used.
+    const largeData = Array.from({ length: 200000 }, (_, i) => ({ value: i }));
+    const numericEntries = [10000, 190000];
+
+    // This should not throw an error
+    expect(() => {
+      const result = getOutOfBandFlags(largeData, numericEntries);
+      expect(result.belowMin).toBe(true);
+      expect(result.aboveMax).toBe(true);
+    }).not.toThrow();
+  });
+});

--- a/packages/vis-core/src/utils/map.js
+++ b/packages/vis-core/src/utils/map.js
@@ -847,6 +847,10 @@ export const reclassifyData = (
       return bins;
     }
 
+    if (bins.length === 1) {
+      return [0, bins[0]];
+    }
+
     return [0, ...bins.slice(1)];
   };
 


### PR DESCRIPTION
### **Problem 1 - Replace Math.min/max spread with reduce in getOutOfBandFlags**
`Math.min(...values)` / `Math.max(...values)` in `getOutOfBandFlags` spread the array into individual function arguments. JS engines cap function call arguments at ~65,536, so any array larger than that throws `RangeError: Maximum call stack size exceeded`. This hits in practice when zooming triggers more vector tile features than that threshold.

### _Fix 1_
Replaced all four `Math.min(...)`/`Math.max(...)` spread calls in `getOutOfBandFlags` (`bandMin`, `bandMax`, and the two comparisons on `values`) with `Array.prototype.reduce`, using module-scope reducer callbacks:

```javascript
const minReducer = (min, v) => (v < min ? v : min);
const maxReducer = (max, v) => (v > max ? v : max);
```

No behavioural change -- `reduce` with these callbacks returns identical results to the spread version for all finite-array inputs, including the empty-array edge case (both return `Infinity`/`-Infinity`).

### **Problem 2 - Fix single-value bin collapse**
`normaliseContinuousBins` forces the first element of a bins array to 0 using [0, ...bins.slice(1)]. When the bins array has only a single element (e.g. API returns just 4.74 as the sole value), slice(1) returns an empty array, so there's nothing left to spread back in. The result collapses to [0] instead of [0, 4.74], silently dropping the only real value.

### _Fix 2_
Added an explicit check for the length-1 case to retain the original value alongside the forced `0`:
`if (bins.length === 1) {
  return [0, bins[0]];
}`
No change to behaviour for arrays with 2+ elements.

- Closes #248 
- Closes #251 