### PR TITLE
Prevent callout cards from reordering during data refreshes and add user signals to show when hidden cards are available/cards have updated

### DIFF
--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
@@ -32,7 +32,8 @@ import { api } from "services";
  * @param {Function} [props.onUpdate] - Backwards-compatible callback when card data updates
  * @param {Function} [props.onFirstVisible] - Callback fired once when the card first renders with data
  * @param {Function} [props.onVisibilityChange] - Callback fired when the card becomes visible/hidden
- * @param {Function} [props.onCardUpdated]
+ * @param {Function} [props.onCardUpdated] - Callback fired when hydrated card data changes.
+ * @param {Function} [props.onCardUpdateAcknowledged] - Callback fired when the user opens an updated card.
  * @param {string} [props.locationFilterId] - Optional explicit filter id to drive navigation
  * @param {Function} [props.getAllColors]
  *
@@ -80,7 +81,10 @@ export const BaseCalloutCardVisualisation = ({
   const responseData = response.data;
   const remoteIsLoading = response.isLoading;
 
-  // Capture current data for rehydration
+  /**
+   * Keeps the latest rendered data available so refreshes can show the previous
+   * card content while the next response is loading.
+   */
   useEffect(() => {
     if (data !== null && data !== undefined) {
       previousDataRef.current = data;
@@ -362,7 +366,7 @@ export const BaseCalloutCardVisualisation = ({
     const locationFilter = resolveLocationFilter(state.filters);
     const ranFilterActions = runFilterActions(locationFilter, targetLocationId);
 
-    // Fallback preserves previous implementation 
+    // Fallback preserves previous implementation
     if (!ranFilterActions) {
       dispatch({
         type: actionTypes.UPDATE_PATH_PARAMS,

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
@@ -22,16 +22,19 @@ import { api } from "services";
  * - Keeps previous data visible during refreshes after first hydration.
  * - Sends onFirstVisible through to the small callout card so the manager can move it
  *   to the top once, without reordering on every later data update.
+ * - Sends onCardUpdated through so updated cards can show a per-card ping and stack hint.
  *
  * @component
- * @param {Object} props - The component props
+ * @param {Object} props
  * @param {'small' | 'fullscreen'} [props.type='small'] - Display type of the card
  * @param {string} props.visualisationName - Name of the visualization from context
  * @param {string} props.cardName - Unique name identifier for the card
  * @param {Function} [props.onUpdate] - Backwards-compatible callback when card data updates
  * @param {Function} [props.onFirstVisible] - Callback fired once when the card first renders with data
  * @param {Function} [props.onVisibilityChange] - Callback fired when the card becomes visible/hidden
+ * @param {Function} [props.onCardUpdated]
  * @param {string} [props.locationFilterId] - Optional explicit filter id to drive navigation
+ * @param {Function} [props.getAllColors]
  *
  * @returns {JSX.Element|null} The rendered card component or null if loading/hidden
  */
@@ -42,6 +45,8 @@ export const BaseCalloutCardVisualisation = ({
   onUpdate,
   onFirstVisible,
   onVisibilityChange,
+  onCardUpdated,
+  onCardUpdateAcknowledged,
   locationFilterId,
   getAllColors,
   ...props
@@ -287,7 +292,9 @@ export const BaseCalloutCardVisualisation = ({
 
     if (byField) return byField;
 
-    return filters.find((f) => Array.isArray(f.actions) && f.actions.length) || null;
+    return (
+      filters.find((f) => Array.isArray(f.actions) && f.actions.length) || null
+    );
   };
 
   /**
@@ -399,6 +406,8 @@ export const BaseCalloutCardVisualisation = ({
       onUpdate={onUpdate}
       onFirstVisible={onFirstVisible}
       onVisibilityChange={onVisibilityChange}
+      onCardUpdated={onCardUpdated}
+      onCardUpdateAcknowledged={onCardUpdateAcknowledged}
       data={displayData}
       isLoading={showInitialLoading}
       isUpdating={showUpdating}

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
@@ -391,7 +391,7 @@ export const BaseCalloutCardVisualisation = ({
       ? data ?? previousDataRef.current
       : data;
 
-  const showInitialLoading = remoteIsLoading && !hasHydrated;
+  const showInitialLoading = remoteIsLoading && !hasHydrated && !displayData;
   const showUpdating = remoteIsLoading && hasHydrated;
 
   return type === "fullscreen" ? (

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
@@ -34,6 +34,7 @@ import { api } from "services";
  * @param {Function} [props.onVisibilityChange] - Callback fired when the card becomes visible/hidden
  * @param {Function} [props.onCardUpdated] - Callback fired when hydrated card data changes.
  * @param {Function} [props.onCardUpdateAcknowledged] - Callback fired when the user opens an updated card.
+ * @param {boolean} [props.hideHandleOnMobile] - Hide the desktop card toggle in mobile stacked layout.
  * @param {string} [props.locationFilterId] - Optional explicit filter id to drive navigation
  * @param {Function} [props.getAllColors]
  *
@@ -48,6 +49,7 @@ export const BaseCalloutCardVisualisation = ({
   onVisibilityChange,
   onCardUpdated,
   onCardUpdateAcknowledged,
+  hideHandleOnMobile,
   locationFilterId,
   getAllColors,
   ...props
@@ -415,6 +417,7 @@ export const BaseCalloutCardVisualisation = ({
       data={displayData}
       isLoading={showInitialLoading}
       isUpdating={showUpdating}
+      hideHandleOnMobile={hideHandleOnMobile}
       getAllColors={getAllColors ?? injectedGetAllColors}
       recordSelector={
         hasMultipleRecords ? (

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/BaseCalloutCardVisualisation.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState, useContext, useRef } from "react";
 import { FullScreenCalloutCardVisualisation } from "./FullScreenCalloutCardVisualisation";
 import { CalloutCardVisualisation } from "./CalloutCardVisualisation";
 import { RecordSelector } from "./RecordSelector";
@@ -18,13 +18,20 @@ import { api } from "services";
  * mirror Map's behavior. This ensures any configured actions tied to the location filter
  * are executed rather than hard-coded path-param updates.
  *
+ * Behaviour:
+ * - Keeps previous data visible during refreshes after first hydration.
+ * - Sends onFirstVisible through to the small callout card so the manager can move it
+ *   to the top once, without reordering on every later data update.
+ *
  * @component
  * @param {Object} props - The component props
  * @param {'small' | 'fullscreen'} [props.type='small'] - Display type of the card
  * @param {string} props.visualisationName - Name of the visualization from context
  * @param {string} props.cardName - Unique name identifier for the card
- * @param {Function} [props.onUpdate] - Callback function when card data updates
- * @param {string} [props.locationFilterId] - Optional explicit filter id to drive navigation (overrides heuristic resolution)
+ * @param {Function} [props.onUpdate] - Backwards-compatible callback when card data updates
+ * @param {Function} [props.onFirstVisible] - Callback fired once when the card first renders with data
+ * @param {Function} [props.onVisibilityChange] - Callback fired when the card becomes visible/hidden
+ * @param {string} [props.locationFilterId] - Optional explicit filter id to drive navigation
  *
  * @returns {JSX.Element|null} The rendered card component or null if loading/hidden
  */
@@ -33,6 +40,8 @@ export const BaseCalloutCardVisualisation = ({
   visualisationName,
   cardName,
   onUpdate,
+  onFirstVisible,
+  onVisibilityChange,
   locationFilterId,
   getAllColors,
   ...props
@@ -44,13 +53,14 @@ export const BaseCalloutCardVisualisation = ({
   const visualisation = state.visualisations[visualisationName];
 
   const [data, setData] = useState(null);
+  const previousDataRef = useRef(null);
   const [hasHydrated, setHasHydrated] = useState(false);
-  
+
   // State for handling multiple records
   const [allRecords, setAllRecords] = useState([]);
   const [selectedRecordIndex, setSelectedRecordIndex] = useState(0);
   const [hasMultipleRecords, setHasMultipleRecords] = useState(false);
-  
+
   // Flag to prevent data reset when user has made a selection
   const [userHasSelectedRecord, setUserHasSelectedRecord] = useState(false);
 
@@ -65,8 +75,15 @@ export const BaseCalloutCardVisualisation = ({
   const responseData = response.data;
   const remoteIsLoading = response.isLoading;
 
+  // Capture current data for rehydration
+  useEffect(() => {
+    if (data !== null && data !== undefined) {
+      previousDataRef.current = data;
+    }
+  }, [data]);
+
   /**
-   * Synchronizes the displayed data with the fetched data,
+   * Synchronises the displayed data with the fetched data,
    * except when we are in a transition (showing prefetched data).
    * Handles both single records and arrays of multiple records.
    */
@@ -75,10 +92,10 @@ export const BaseCalloutCardVisualisation = ({
       // Check if response data is an array
       if (Array.isArray(responseData)) {
         const isNewDataSet = allRecords.length !== responseData.length;
-        
+
         setAllRecords(responseData);
         setHasMultipleRecords(responseData.length > 1);
-        
+
         if (responseData.length > 0) {
           // Only reset selection if this is new data or user hasn't made a selection
           if (isNewDataSet || !userHasSelectedRecord) {
@@ -89,8 +106,13 @@ export const BaseCalloutCardVisualisation = ({
             setUserHasSelectedRecord(false);
           } else {
             // Preserve current selection if possible
-            const validIndex = selectedRecordIndex < responseData.length ? selectedRecordIndex : responseData.length - 1;
+            const validIndex =
+              selectedRecordIndex < responseData.length
+                ? selectedRecordIndex
+                : responseData.length - 1;
+
             setData(responseData[validIndex]);
+
             if (validIndex !== selectedRecordIndex) {
               setSelectedRecordIndex(validIndex);
             }
@@ -106,7 +128,7 @@ export const BaseCalloutCardVisualisation = ({
         setSelectedRecordIndex(0);
         setUserHasSelectedRecord(false);
       }
-      
+
       // Once we have any data, consider initial hydration complete and stop showing loading flashes
       if (!hasHydrated) setHasHydrated(true);
     }
@@ -139,7 +161,6 @@ export const BaseCalloutCardVisualisation = ({
    * @param {number} index - Index of the selected record
    */
   const handleRecordSelection = (index) => {
-    
     if (index >= 0 && index < allRecords.length) {
       setSelectedRecordIndex(index);
       setUserHasSelectedRecord(true);
@@ -155,8 +176,12 @@ export const BaseCalloutCardVisualisation = ({
    * @returns {string} Display label
    */
   const getRecordLabel = (record) => {
-    // Try to get a meaningful label from the record
-    return record.title || record.name || record.reference_id || `Record ${allRecords.indexOf(record) + 1}`;
+    return (
+      record.title ||
+      record.name ||
+      record.reference_id ||
+      `Record ${allRecords.indexOf(record) + 1}`
+    );
   };
 
   /**
@@ -171,8 +196,9 @@ export const BaseCalloutCardVisualisation = ({
       !locationId ||
       (mode === "next" && nextData) ||
       (mode === "previous" && prevData)
-    )
+    ) {
       return;
+    }
 
     const nextVisu = {
       ...visualisation,
@@ -183,7 +209,9 @@ export const BaseCalloutCardVisualisation = ({
         },
       },
     };
+
     const dataUpdated = await prefetch(nextVisu);
+
     if (dataUpdated && mode === "next") setNextData(dataUpdated);
     if (dataUpdated && mode === "previous") setPrevData(dataUpdated);
   };
@@ -209,12 +237,13 @@ export const BaseCalloutCardVisualisation = ({
    * @param {Object} nextVisu - Visualisation config for the location to fetch
    * @returns {Promise<Object>} - The fetched data
    */
-  async function prefetch(nextVisu, mode) {
+  async function prefetch(nextVisu) {
     const response = await api.baseService.get(nextVisu.dataPath, {
       pathParams: toSimpleParamsMap(nextVisu.pathParams),
       queryParams: toSimpleParamsMap(nextVisu.queryParams),
       skipAuth: !nextVisu.requiresAuth,
     });
+
     return response;
   }
 
@@ -231,6 +260,7 @@ export const BaseCalloutCardVisualisation = ({
    */
   const resolveLocationFilter = (filters) => {
     if (!Array.isArray(filters) || filters.length === 0) return null;
+
     if (locationFilterId) {
       return filters.find((f) => f.id === locationFilterId) || null;
     }
@@ -248,11 +278,13 @@ export const BaseCalloutCardVisualisation = ({
               : true)
         )
     );
+
     if (byPathParam) return byPathParam;
 
     const byField = filters.find((f) =>
       ["id", "location_id", "loc_id"].includes(f.field)
     );
+
     if (byField) return byField;
 
     return filters.find((f) => Array.isArray(f.actions) && f.actions.length) || null;
@@ -297,6 +329,7 @@ export const BaseCalloutCardVisualisation = ({
    */
   const change = (mode) => {
     let targetData = null;
+
     switch (mode) {
       case "next":
         targetData = nextData;
@@ -335,15 +368,24 @@ export const BaseCalloutCardVisualisation = ({
         },
       });
     }
+
     setNextData(null);
     setPrevData(null);
   };
 
+  const displayData =
+    remoteIsLoading && hasHydrated
+      ? data ?? previousDataRef.current
+      : data;
+
+  const showInitialLoading = remoteIsLoading && !hasHydrated;
+  const showUpdating = remoteIsLoading && hasHydrated;
 
   return type === "fullscreen" ? (
     <FullScreenCalloutCardVisualisation
-      data={data}
-      isLoading={remoteIsLoading}
+      data={displayData}
+      isLoading={showInitialLoading}
+      isUpdating={showUpdating}
       handleUpdatedData={(locationId, mode) => {
         onUpdateData(locationId, mode);
       }}
@@ -355,17 +397,22 @@ export const BaseCalloutCardVisualisation = ({
       visualisationName={visualisationName}
       cardName={cardName}
       onUpdate={onUpdate}
-      data={data}
-      isLoading={remoteIsLoading}
+      onFirstVisible={onFirstVisible}
+      onVisibilityChange={onVisibilityChange}
+      data={displayData}
+      isLoading={showInitialLoading}
+      isUpdating={showUpdating}
       getAllColors={getAllColors ?? injectedGetAllColors}
-      recordSelector={hasMultipleRecords ? (
-        <RecordSelector
-          records={allRecords}
-          selectedIndex={selectedRecordIndex}
-          onSelect={handleRecordSelection}
-          getRecordLabel={getRecordLabel}
-        />
-      ) : null}
+      recordSelector={
+        hasMultipleRecords ? (
+          <RecordSelector
+            records={allRecords}
+            selectedIndex={selectedRecordIndex}
+            onSelect={handleRecordSelection}
+            getRecordLabel={getRecordLabel}
+          />
+        ) : null
+      }
     />
   );
 };

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
@@ -47,15 +47,19 @@ const CardContainer = styled.div`
   background-color: white;
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+
   padding: ${PADDING}px;
   z-index: 1000;
+
   transition: transform 0.3s ease-in-out, height 0.3s ease-in-out;
-  transform: translateX(${({ $isVisible }) => ($isVisible ? "0" : `100%`)});
-  overflow: hidden; /* Prevent content overflow */
+  transform: translateX(${({ $isVisible }) => ($isVisible ? "0" : "100%")});
+
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
   flex-grow: 0;
+
   height: ${({ $isVisible }) => ($isVisible ? "auto" : `${PADDING * 2}px`)};
 
   @media ${(props) => props.theme.mq.mobile} {
@@ -63,6 +67,14 @@ const CardContainer = styled.div`
     box-shadow: none;
     flex-shrink: 1;
   }
+`;
+
+const CardHeader = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 82px;
+  align-items: start;
+  gap: 8px;
+  min-height: 30px;
 `;
 
 /**
@@ -75,12 +87,46 @@ const CardTitle = styled.h2`
   margin-top: 5px;
   user-select: none;
   background-color: rgba(255, 255, 255, 0);
+  min-width: 0;
 
   @media ${(props) => props.theme.mq.mobile} {
     font-size: 1.2em;
     text-align: left;
     margin: 0;
   }
+`;
+
+const StatusSlot = styled.div`
+  min-width: 82px;
+  min-height: 22px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding-top: 4px;
+`;
+
+const StatusBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  max-width: 82px;
+  padding: 2px 7px;
+
+  border-radius: 999px;
+  background: ${({ $kind }) =>
+    $kind === "updated"
+      ? "rgba(0, 222, 198, 0.18)"
+      : "rgba(240, 240, 247, 0.95)"};
+  color: ${({ $kind }) =>
+    $kind === "updated" ? "rgb(13, 15, 61)" : "#4b3e91"};
+
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.3;
+  white-space: nowrap;
+
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
 `;
 
 /**
@@ -136,21 +182,13 @@ const CardContent = styled.div`
     flex: 0 0 auto;
   }
 
-  .row {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 16px;
-    padding: 0 0px;
-    justify-content: center;
-  }
-
+  .row,
   .row.small {
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: 16px;
-    padding: 0 0px;
+    padding: 0;
     justify-content: center;
   }
 
@@ -209,42 +247,6 @@ const CardContent = styled.div`
   }
 `;
 
-const CardHeader = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 82px;
-  align-items: start;
-  gap: 8px;
-`;
-
-const UpdatingSlot = styled.div`
-  min-width: 82px;
-  min-height: 22px;
-  display: flex;
-  align-items: flex-start;
-  justify-content: flex-end;
-  padding-top: 4px;
-`;
-
-const UpdatingBadge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: fit-content;
-  max-width: 82px;
-  padding: 2px 7px;
-  border-radius: 999px;
-  background: rgba(240, 240, 247, 0.95);
-  color: #4b3e91;
-  font-size: 0.72rem;
-  font-weight: 600;
-  line-height: 1.3;
-  white-space: nowrap;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
-`;
-
-/**
- * Styled component for the toggle button.
- */
 const ToggleButton = styled.button`
   position: absolute;
   top: ${PADDING}px;
@@ -258,11 +260,46 @@ const ToggleButton = styled.button`
   border-radius: 5px;
   padding: 0;
   cursor: pointer;
+
   display: flex;
   align-items: center;
   justify-content: center;
+
   transition: right 0.3s ease-in-out;
 `;
+
+const TogglePing = styled.span`
+  position: absolute;
+  top: -6px;
+  right: -6px;
+
+  min-width: 17px;
+  height: 17px;
+  padding: 0 4px;
+
+  border-radius: 999px;
+  background: ${({ $kind }) => ($kind === "updated" ? "#00dec6" : "#f0f0f7")};
+  color: rgb(13, 15, 61);
+
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 17px;
+  text-align: center;
+
+  box-shadow:
+    0 0 0 2px #fff,
+    0 2px 6px rgba(0, 0, 0, 0.25);
+
+  pointer-events: none;
+`;
+
+const safeStringify = (value) => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
 
 /**
  * CalloutCardVisualisation component to display a card-like element within the map.
@@ -272,9 +309,15 @@ const ToggleButton = styled.button`
  * @param {string} [props.cardName] - Optional name for the card.
  * @param {Function} [props.onUpdate] - Backwards-compatible function to call when the card first becomes visible.
  * @param {Function} [props.onFirstVisible] - Function to call when the card first becomes visible.
+ * @param {Function} [props.onCardUpdated]
  * @param {Object} props.data - Data used by the card.
- * @param {boolean} props.isLoading - Whether this is the initial loading state.
+ * @param {boolean} props.isLoading- Whether this is the initial loading state.
  * @param {boolean} props.isUpdating - Whether data is refreshing after first hydration.
+ * @param {boolean} [props.hideHandleOnMobile]
+ * @param {Function} [props.onVisibilityChange]
+ * @param {React.ReactNode} [props.recordSelector]
+ * @param {Function} [props.toggleVisibility]
+ * @param {Function} [props.getAllColors]
  * @returns {JSX.Element|null} The rendered CalloutCardVisualisation component.
  */
 export const CalloutCardVisualisation = ({
@@ -282,6 +325,8 @@ export const CalloutCardVisualisation = ({
   cardName,
   onUpdate,
   onFirstVisible,
+  onCardUpdated,
+  onCardUpdateAcknowledged,
   data,
   isLoading,
   isUpdating = false,
@@ -293,9 +338,19 @@ export const CalloutCardVisualisation = ({
 }) => {
   const { state } = useContext(MapContext);
   const visualisation = state.visualisations[visualisationName];
+
   const buttonRef = useRef(null);
   const contentRef = useRef(null);
   const hasFiredFirstVisibleRef = useRef(false);
+  const previousDataSignatureRef = useRef(null);
+  const updatePingTimerRef = useRef(null);
+  const isVisibleRef = useRef(false);
+
+  const [isVisible, setIsVisible] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [recentlyUpdated, setRecentlyUpdated] = useState(false);
+
+  const showHandle = !hideHandleOnMobile;
 
   const colorsList = useMemo(() => {
     if (typeof getAllColors === "function") return getAllColors();
@@ -306,27 +361,69 @@ export const CalloutCardVisualisation = ({
   // Do not render the card if no data is available,
   // or if the data is an empty object,
   // or if every value in the data dictionary is nullish.
-  let hasDataShouldRender = true;
+  const hasDataShouldRender = useMemo(() => {
+    if (!data) return false;
+    if (typeof data !== "object") return true;
 
-  if (
-    !data ||
-    Object.keys(data).length === 0 ||
-    Object.values(data).every(
+    const values = Object.values(data);
+
+    if (values.length === 0) return false;
+
+    return !values.every(
       (value) => value === null || value === undefined || value === 0
-    )
-  ) {
-    hasDataShouldRender = false;
-  }
+    );
+  }, [data]);
 
   const actuallyVisible = !isLoading && hasDataShouldRender;
 
-  useEffect(() => {
-    if (onVisibilityChange) onVisibilityChange(actuallyVisible);
+  const dataUpdateSignature = useMemo(() => {
+    if (!data) return "";
 
-    return () => {
-      if (onVisibilityChange) onVisibilityChange(false);
-    };
-  }, [actuallyVisible, onVisibilityChange]);
+    try {
+      return JSON.stringify(data);
+    } catch {
+      return String(data);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    isVisibleRef.current = isVisible;
+  }, [isVisible]);
+
+  // Effect to ping user with timeout if updated and visible
+  useEffect(() => {
+    if (!actuallyVisible) return;
+    if (!dataUpdateSignature) return;
+
+    if (previousDataSignatureRef.current === null) {
+      previousDataSignatureRef.current = dataUpdateSignature;
+      return;
+    }
+
+    if (previousDataSignatureRef.current === dataUpdateSignature) {
+      return;
+    }
+
+    previousDataSignatureRef.current = dataUpdateSignature;
+
+    setRecentlyUpdated(true);
+    onCardUpdated?.();
+
+    if (updatePingTimerRef.current) {
+      clearTimeout(updatePingTimerRef.current);
+    }
+
+    updatePingTimerRef.current = setTimeout(() => {
+      /**
+       * Only auto-clear the updated ping if the card is open.
+       * If the card is closed/collapsed, keep the handle ping visible until
+       * the user opens the card.
+       */
+      if (isVisibleRef.current) {
+        setRecentlyUpdated(false);
+      }
+    }, 2800);
+  }, [actuallyVisible, dataUpdateSignature, onCardUpdated]);
 
   // Effect to (for example) shoot to top of the list if first render
   useEffect(() => {
@@ -346,18 +443,49 @@ export const CalloutCardVisualisation = ({
     }
   }, [actuallyVisible, onFirstVisible, onUpdate]);
 
-  // Slide-in: start hidden and slide to visible once the card truly has content.
-  const [isVisible, setIsVisible] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
-  const showHandle = !hideHandleOnMobile;
+  useEffect(() => {
+    if (!actuallyVisible) return;
+    if (!dataUpdateSignature) return;
 
-  // Trigger initial slide-in when the card first becomes actually visible
+    if (previousDataSignatureRef.current === null) {
+      previousDataSignatureRef.current = dataUpdateSignature;
+      return;
+    }
+
+    if (previousDataSignatureRef.current === dataUpdateSignature) {
+      return;
+    }
+
+    previousDataSignatureRef.current = dataUpdateSignature;
+
+    setRecentlyUpdated(true);
+    onCardUpdated?.();
+
+    if (updatePingTimerRef.current) {
+      clearTimeout(updatePingTimerRef.current);
+    }
+
+    updatePingTimerRef.current = setTimeout(() => {
+      setRecentlyUpdated(false);
+    }, 2800);
+  }, [actuallyVisible, dataUpdateSignature, onCardUpdated]);
+
+  useEffect(() => {
+    return () => {
+      if (updatePingTimerRef.current) {
+        clearTimeout(updatePingTimerRef.current);
+      }
+    };
+  }, []);
+
   useEffect(() => {
     if (actuallyVisible) {
       // next frame ensures CSS transition fires
       const id = requestAnimationFrame(() => setIsVisible(true));
       return () => cancelAnimationFrame(id);
     }
+
+    return undefined;
   }, [actuallyVisible]);
 
   // Respect hideHandleOnMobile: when true, ensure the card is visible (still slides in on first actual visibility)
@@ -372,11 +500,38 @@ export const CalloutCardVisualisation = ({
     if (externalToggleVisibility) {
       externalToggleVisibility();
     } else {
-      setIsVisible((v) => !v);
+      setIsVisible((current) => {
+        const next = !current;
+
+        /**
+         * Opening the card acknowledges the update immediately.
+         * Closing it does not.
+         */
+        if (next) {
+          setRecentlyUpdated(false);
+
+          if (updatePingTimerRef.current) {
+            clearTimeout(updatePingTimerRef.current);
+            updatePingTimerRef.current = null;
+          }
+
+          onCardUpdateAcknowledged?.();
+        }
+
+        return next;
+      });
     }
 
     setIsHovered(false);
   };
+
+  useEffect(() => {
+    return () => {
+      if (updatePingTimerRef.current) {
+        clearTimeout(updatePingTimerRef.current);
+      }
+    };
+  }, []);
 
   const formatNumberWithUnit = useCallback((value, unit = "") => {
     if (value === null || value === undefined || isNaN(value)) return "N/A";
@@ -385,15 +540,15 @@ export const CalloutCardVisualisation = ({
 
   const customFormattingFunctions = useMemo(
     () => ({
-      ...(visualisation.customFormattingFunctions || {}),
+      ...(visualisation?.customFormattingFunctions || {}),
       formatNumberWithUnit,
     }),
-    [visualisation.customFormattingFunctions, formatNumberWithUnit]
+    [visualisation?.customFormattingFunctions, formatNumberWithUnit]
   );
 
   // Batch compute the sanitised HTML and dynamic title together to avoid multi-step updates
   const { sanitizedHtml, safeDynamicTitle } = useMemo(() => {
-    if (!data) {
+    if (!data || !visualisation) {
       return { sanitizedHtml: "", safeDynamicTitle: "" };
     }
 
@@ -416,13 +571,49 @@ export const CalloutCardVisualisation = ({
       ALLOWED_ATTR: [],
     });
 
-    return { sanitizedHtml: htmlFromFragment, safeDynamicTitle: safeTitle };
+    return {
+      sanitizedHtml: htmlFromFragment,
+      safeDynamicTitle: safeTitle,
+    };
   }, [
     data,
-    visualisation.htmlFragment,
-    visualisation.cardTitle,
+    visualisation,
+    visualisation?.htmlFragment,
+    visualisation?.cardTitle,
     customFormattingFunctions,
   ]);
+
+  const statusKind = isUpdating
+    ? "updating"
+    : recentlyUpdated
+    ? "updated"
+    : null;
+
+  const statusLabel =
+    statusKind === "updating"
+      ? "Updating…"
+      : statusKind === "updated"
+      ? "Updated"
+      : "";
+
+  const renderStatusBadge = () => {
+    if (!statusKind) return null;
+
+    return (
+      <StatusBadge $kind={statusKind} role="status">
+        {statusLabel}
+      </StatusBadge>
+    );
+  };
+
+  const renderCardHeader = (title, { showStatus = true } = {}) => (
+    <CardHeader>
+      <CardTitle>{title}</CardTitle>
+      <StatusSlot aria-live="polite">
+        {showStatus ? renderStatusBadge() : null}
+      </StatusSlot>
+    </CardHeader>
+  );
 
   const renderHandle = () =>
     showHandle ? (
@@ -430,15 +621,27 @@ export const CalloutCardVisualisation = ({
         <ToggleButton
           ref={buttonRef}
           $isVisible={isVisible}
+          data-callout-card-toggle
+          data-callout-card-toggle-for={visualisationName}
           onClick={toggleVisibility}
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
-          aria-label={isVisible ? `Hide ${cardName || "Card"}` : `Show ${cardName || "Card"}`}
+          aria-label={
+            isVisible
+              ? `Hide ${cardName || "Card"}`
+              : `Show ${cardName || "Card"}`
+          }
         >
           {isVisible ? (
             <ChevronRightIcon style={{ width: "20px", height: "20px" }} />
           ) : (
             <ChevronLeftIcon style={{ width: "20px", height: "20px" }} />
+          )}
+
+          {statusKind && (
+            <TogglePing $kind={statusKind} aria-hidden="true">
+              {statusKind === "updated" ? "!" : "•"}
+            </TogglePing>
           )}
         </ToggleButton>
 
@@ -456,25 +659,17 @@ export const CalloutCardVisualisation = ({
       </>
     ) : null;
 
-  const renderCardHeader = (title, { showUpdating = true } = {}) => (
-    <CardHeader>
-      <CardTitle>{title}</CardTitle>
+  if (!visualisation) return null;
 
-      <UpdatingSlot aria-live="polite">
-        {showUpdating && isUpdating ? (
-          <UpdatingBadge role="status">Updating…</UpdatingBadge>
-        ) : null}
-      </UpdatingSlot>
-    </CardHeader>
-  );
-
-  // Loading shell: initial load only. After hydration, BaseCalloutCardVisualisation
-  // keeps previous data visible and sends isUpdating instead.
   if (isLoading) {
     return (
-      <ParentContainer $isVisible={isVisible}>
+      <ParentContainer
+        $isVisible={isVisible}
+        data-callout-card-name={visualisationName}
+        data-callout-card-open={isVisible ? "true" : "false"}
+      >
         <CardContainer $isVisible={isVisible}>
-          {renderCardHeader("Loading...", { showUpdating: false })}
+          {renderCardHeader("Loading...", { showStatus: false })}
           <CardContent>
             <h3>Loading...</h3>
           </CardContent>
@@ -491,7 +686,11 @@ export const CalloutCardVisualisation = ({
 
   if (visualisation.layout && visualisation.layout.length > 0) {
     return (
-      <ParentContainer $isVisible={isVisible}>
+      <ParentContainer
+        $isVisible={isVisible}
+        data-callout-card-name={visualisationName}
+        data-callout-card-open={isVisible ? "true" : "false"}
+      >
         <CardContainer $isVisible={isVisible}>
           {renderCardHeader(cardName)}
 
@@ -525,7 +724,7 @@ export const CalloutCardVisualisation = ({
                 }
 
                 const allGraphs = Object.entries(data)
-                  .filter(([key, obj]) => obj && obj.type !== undefined)
+                  .filter(([, obj]) => obj && obj.type !== undefined)
                   .map(([key, obj]) => ({ key, ...obj }));
                 // Association of networks has a colour
                 const networkColorMap = {};
@@ -542,7 +741,7 @@ export const CalloutCardVisualisation = ({
                       if (network && !(network in networkColorMap)) {
                         networkColorMap[network] =
                           colorsList[colorIdx % colorsList.length];
-                        colorIdx++;
+                        colorIdx += 1;
                       }
                     });
                   }
@@ -565,6 +764,8 @@ export const CalloutCardVisualisation = ({
                     };
 
                   // Dynamic title for ranking charts
+                  let chartData;
+
                   if (
                     (chart.type === "ranking" &&
                       visualisation.queryParams?.dataTypeName?.value !==
@@ -656,7 +857,11 @@ export const CalloutCardVisualisation = ({
 
   // Render the card with dynamic content
   return (
-    <ParentContainer $isVisible={isVisible}>
+    <ParentContainer
+        $isVisible={isVisible}
+        data-callout-card-name={visualisationName}
+        data-callout-card-open={isVisible ? "true" : "false"}
+      >
       <CardContainer $isVisible={isVisible}>
         {renderCardHeader(cardName)}
 

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
@@ -18,6 +18,7 @@ import { CARD_CONSTANTS } from "defaults";
 
 const { CARD_WIDTH, PADDING, TOGGLE_BUTTON_WIDTH, TOGGLE_BUTTON_HEIGHT } =
   CARD_CONSTANTS;
+const UPDATE_MARKER_TIMEOUT_MS = 2800;
 
 /**
  * Styled component for the parent container.
@@ -315,7 +316,7 @@ const safeStringify = (value) => {
  * @param {string} [props.cardName] - Optional name for the card.
  * @param {Function} [props.onUpdate] - Backwards-compatible function to call when the card first becomes visible.
  * @param {Function} [props.onFirstVisible] - Function to call when the card first becomes visible.
- * @param {Function} [props.onCardUpdated] - Callback fired when hydrated card data changes.
+ * @param {Function} [props.onCardUpdated] - Callback fired with update expiry details when hydrated card data changes.
  * @param {Function} [props.onCardUpdateAcknowledged] - Callback fired when the user opens an updated card.
  * @param {Object} props.data - Data used by the card.
  * @param {boolean} props.isLoading- Whether this is the initial loading state.
@@ -422,8 +423,10 @@ export const CalloutCardVisualisation = ({
 
     previousDataSignatureRef.current = dataUpdateSignature;
 
+    const autoClearAt = Date.now() + UPDATE_MARKER_TIMEOUT_MS;
+
     setRecentlyUpdated(true);
-    onCardUpdated?.();
+    onCardUpdated?.({ autoClearAt, timeoutMs: UPDATE_MARKER_TIMEOUT_MS });
 
     if (updatePingTimerRef.current) {
       clearTimeout(updatePingTimerRef.current);
@@ -438,7 +441,7 @@ export const CalloutCardVisualisation = ({
       if (isVisibleRef.current) {
         setRecentlyUpdated(false);
       }
-    }, 2800);
+    }, Math.max(0, autoClearAt - Date.now()));
   }, [actuallyVisible, dataUpdateSignature, onCardUpdated]);
 
   /**

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
@@ -209,10 +209,37 @@ const CardContent = styled.div`
   }
 `;
 
-const UpdatingText = styled.p`
-  font-size: 0.85em !important;
-  margin: 0 0 6px !important;
-  color: #666 !important;
+const CardHeader = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 82px;
+  align-items: start;
+  gap: 8px;
+`;
+
+const UpdatingSlot = styled.div`
+  min-width: 82px;
+  min-height: 22px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding-top: 4px;
+`;
+
+const UpdatingBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  max-width: 82px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: rgba(240, 240, 247, 0.95);
+  color: #4b3e91;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
 `;
 
 /**
@@ -429,13 +456,25 @@ export const CalloutCardVisualisation = ({
       </>
     ) : null;
 
+  const renderCardHeader = (title, { showUpdating = true } = {}) => (
+    <CardHeader>
+      <CardTitle>{title}</CardTitle>
+
+      <UpdatingSlot aria-live="polite">
+        {showUpdating && isUpdating ? (
+          <UpdatingBadge role="status">Updating…</UpdatingBadge>
+        ) : null}
+      </UpdatingSlot>
+    </CardHeader>
+  );
+
   // Loading shell: initial load only. After hydration, BaseCalloutCardVisualisation
   // keeps previous data visible and sends isUpdating instead.
   if (isLoading) {
     return (
       <ParentContainer $isVisible={isVisible}>
         <CardContainer $isVisible={isVisible}>
-          <CardTitle>Loading...</CardTitle>
+          {renderCardHeader("Loading...", { showUpdating: false })}
           <CardContent>
             <h3>Loading...</h3>
           </CardContent>
@@ -454,13 +493,7 @@ export const CalloutCardVisualisation = ({
     return (
       <ParentContainer $isVisible={isVisible}>
         <CardContainer $isVisible={isVisible}>
-          <CardTitle>{cardName}</CardTitle>
-
-          {isUpdating && (
-            <CardContent>
-              <UpdatingText>Updating…</UpdatingText>
-            </CardContent>
-          )}
+          {renderCardHeader(cardName)}
 
           {recordSelector}
 
@@ -625,13 +658,7 @@ export const CalloutCardVisualisation = ({
   return (
     <ParentContainer $isVisible={isVisible}>
       <CardContainer $isVisible={isVisible}>
-        <CardTitle>{cardName}</CardTitle>
-
-        {isUpdating && (
-          <CardContent>
-            <UpdatingText>Updating…</UpdatingText>
-          </CardContent>
-        )}
+        {renderCardHeader(cardName)}
 
         {recordSelector}
 

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
@@ -788,7 +788,6 @@ export const CalloutCardVisualisation = ({
                     };
 
                   // Dynamic title for ranking charts
-                  let chartData;
 
                   if (
                     (chart.type === "ranking" &&

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
@@ -293,6 +293,12 @@ const TogglePing = styled.span`
   pointer-events: none;
 `;
 
+/**
+ * Serialises a value for comparison without throwing on unusual inputs.
+ *
+ * @param {any} value - Value to serialise.
+ * @returns {string} JSON output when possible, otherwise `String(value)`.
+ */
 const safeStringify = (value) => {
   try {
     return JSON.stringify(value);
@@ -309,12 +315,13 @@ const safeStringify = (value) => {
  * @param {string} [props.cardName] - Optional name for the card.
  * @param {Function} [props.onUpdate] - Backwards-compatible function to call when the card first becomes visible.
  * @param {Function} [props.onFirstVisible] - Function to call when the card first becomes visible.
- * @param {Function} [props.onCardUpdated]
+ * @param {Function} [props.onCardUpdated] - Callback fired when hydrated card data changes.
+ * @param {Function} [props.onCardUpdateAcknowledged] - Callback fired when the user opens an updated card.
  * @param {Object} props.data - Data used by the card.
  * @param {boolean} props.isLoading- Whether this is the initial loading state.
  * @param {boolean} props.isUpdating - Whether data is refreshing after first hydration.
  * @param {boolean} [props.hideHandleOnMobile]
- * @param {Function} [props.onVisibilityChange]
+ * @param {Function} [props.onVisibilityChange] - Callback fired when real card data becomes renderable or hidden.
  * @param {React.ReactNode} [props.recordSelector]
  * @param {Function} [props.toggleVisibility]
  * @param {Function} [props.getAllColors]
@@ -378,19 +385,28 @@ export const CalloutCardVisualisation = ({
 
   const dataUpdateSignature = useMemo(() => {
     if (!data) return "";
-
-    try {
-      return JSON.stringify(data);
-    } catch {
-      return String(data);
-    }
+    return safeStringify(data);
   }, [data]);
 
+  /**
+   * Mirrors React state into a ref so delayed update-ping timers can tell
+   * whether the card is open without closing over stale state.
+   */
   useEffect(() => {
     isVisibleRef.current = isVisible;
   }, [isVisible]);
 
-  // Effect to ping user with timeout if updated and visible
+  /**
+   * Reports whether this card currently has renderable data.
+   */
+  useEffect(() => {
+    onVisibilityChange?.(actuallyVisible);
+  }, [actuallyVisible, onVisibilityChange]);
+
+  /**
+   * Detects post-hydration data changes, raises the per-card update marker, and
+   * only auto-clears it when the card is open and visible.
+   */
   useEffect(() => {
     if (!actuallyVisible) return;
     if (!dataUpdateSignature) return;
@@ -425,7 +441,9 @@ export const CalloutCardVisualisation = ({
     }, 2800);
   }, [actuallyVisible, dataUpdateSignature, onCardUpdated]);
 
-  // Effect to (for example) shoot to top of the list if first render
+  /**
+   * Fires the first-visible callbacks once, after the card has real data.
+   */
   useEffect(() => {
     if (!actuallyVisible) return;
     if (hasFiredFirstVisibleRef.current) return;
@@ -443,41 +461,10 @@ export const CalloutCardVisualisation = ({
     }
   }, [actuallyVisible, onFirstVisible, onUpdate]);
 
-  useEffect(() => {
-    if (!actuallyVisible) return;
-    if (!dataUpdateSignature) return;
-
-    if (previousDataSignatureRef.current === null) {
-      previousDataSignatureRef.current = dataUpdateSignature;
-      return;
-    }
-
-    if (previousDataSignatureRef.current === dataUpdateSignature) {
-      return;
-    }
-
-    previousDataSignatureRef.current = dataUpdateSignature;
-
-    setRecentlyUpdated(true);
-    onCardUpdated?.();
-
-    if (updatePingTimerRef.current) {
-      clearTimeout(updatePingTimerRef.current);
-    }
-
-    updatePingTimerRef.current = setTimeout(() => {
-      setRecentlyUpdated(false);
-    }, 2800);
-  }, [actuallyVisible, dataUpdateSignature, onCardUpdated]);
-
-  useEffect(() => {
-    return () => {
-      if (updatePingTimerRef.current) {
-        clearTimeout(updatePingTimerRef.current);
-      }
-    };
-  }, []);
-
+  /**
+   * Opens the card on the next animation frame once data is available so the
+   * slide-in transition can run instead of jumping directly to the open state.
+   */
   useEffect(() => {
     if (actuallyVisible) {
       // next frame ensures CSS transition fires
@@ -488,13 +475,16 @@ export const CalloutCardVisualisation = ({
     return undefined;
   }, [actuallyVisible]);
 
-  // Respect hideHandleOnMobile: when true, ensure the card is visible (still slides in on first actual visibility)
+  /**
+   * Keeps mobile-rendered cards open when their handle is intentionally hidden.
+   */
   useEffect(() => {
     if (hideHandleOnMobile) setIsVisible(true);
   }, [hideHandleOnMobile]);
 
   /**
-   * Toggles the visibility of the card.
+   * Toggles the visibility of the card and acknowledges pending update markers
+   * when the user opens a collapsed card.
    */
   const toggleVisibility = () => {
     if (externalToggleVisibility) {
@@ -525,6 +515,9 @@ export const CalloutCardVisualisation = ({
     setIsHovered(false);
   };
 
+  /**
+   * Clears any pending update-ping timer when the card unmounts.
+   */
   useEffect(() => {
     return () => {
       if (updatePingTimerRef.current) {
@@ -533,6 +526,13 @@ export const CalloutCardVisualisation = ({
     };
   }, []);
 
+  /**
+   * Formats numeric placeholder values and appends an optional unit.
+   *
+   * @param {number|string|null|undefined} value - Value to format.
+   * @param {string} [unit=""] - Unit suffix to append.
+   * @returns {string} Formatted value or "N/A" for invalid input.
+   */
   const formatNumberWithUnit = useCallback((value, unit = "") => {
     if (value === null || value === undefined || isNaN(value)) return "N/A";
     return formatNumber(Number(value)) + unit;
@@ -546,7 +546,10 @@ export const CalloutCardVisualisation = ({
     [visualisation?.customFormattingFunctions, formatNumberWithUnit]
   );
 
-  // Batch compute the sanitised HTML and dynamic title together to avoid multi-step updates
+  /**
+   * Builds the sanitised HTML fragment and dynamic title in one memoised step to
+   * avoid intermediate renders with mismatched content.
+   */
   const { sanitizedHtml, safeDynamicTitle } = useMemo(() => {
     if (!data || !visualisation) {
       return { sanitizedHtml: "", safeDynamicTitle: "" };
@@ -596,6 +599,11 @@ export const CalloutCardVisualisation = ({
       ? "Updated"
       : "";
 
+  /**
+   * Renders the transient loading/update status badge in the reserved header slot.
+   *
+   * @returns {JSX.Element|null} Status badge when active.
+   */
   const renderStatusBadge = () => {
     if (!statusKind) return null;
 
@@ -606,6 +614,14 @@ export const CalloutCardVisualisation = ({
     );
   };
 
+  /**
+   * Renders a stable two-column header so status changes do not shift the title.
+   *
+   * @param {string} title - Card title text.
+   * @param {Object} [options] - Header render options.
+   * @param {boolean} [options.showStatus=true] - Whether to show update status.
+   * @returns {JSX.Element} Card header.
+   */
   const renderCardHeader = (title, { showStatus = true } = {}) => (
     <CardHeader>
       <CardTitle>{title}</CardTitle>
@@ -615,6 +631,11 @@ export const CalloutCardVisualisation = ({
     </CardHeader>
   );
 
+  /**
+   * Renders the collapse/expand handle and update ping for desktop cards.
+   *
+   * @returns {JSX.Element|null} Toggle handle when enabled.
+   */
   const renderHandle = () =>
     showHandle ? (
       <>

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.jsx
@@ -1,4 +1,11 @@
-import React, { useEffect, useMemo, useState, useContext, useRef, useCallback } from "react";
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+  useContext,
+  useRef,
+  useCallback,
+} from "react";
 import styled from "styled-components";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/solid";
 import DOMPurify from "dompurify";
@@ -8,6 +15,7 @@ import { replacePlaceholders, formatNumber } from "utils";
 import { Hovertip, WarningBox, ChartRenderer } from "Components";
 
 import { CARD_CONSTANTS } from "defaults";
+
 const { CARD_WIDTH, PADDING, TOGGLE_BUTTON_WIDTH, TOGGLE_BUTTON_HEIGHT } =
   CARD_CONSTANTS;
 
@@ -24,6 +32,7 @@ const ParentContainer = styled.div`
       ? `${CARD_WIDTH + PADDING * 2}px`
       : `${TOGGLE_BUTTON_WIDTH + PADDING}px`};
   transition: width 0.3s ease-in-out;
+
   @media ${(props) => props.theme.mq.mobile} {
     width: 100%;
   }
@@ -48,6 +57,7 @@ const CardContainer = styled.div`
   flex-shrink: 0;
   flex-grow: 0;
   height: ${({ $isVisible }) => ($isVisible ? "auto" : `${PADDING * 2}px`)};
+
   @media ${(props) => props.theme.mq.mobile} {
     width: 100%;
     box-shadow: none;
@@ -65,6 +75,7 @@ const CardTitle = styled.h2`
   margin-top: 5px;
   user-select: none;
   background-color: rgba(255, 255, 255, 0);
+
   @media ${(props) => props.theme.mq.mobile} {
     font-size: 1.2em;
     text-align: left;
@@ -82,6 +93,7 @@ const CardContent = styled.div`
     font-size: 1.5em;
     color: #4b3e91;
     margin-bottom: 0.5em;
+
     @media ${(props) => props.theme.mq.mobile} {
       font-size: 1.2em;
     }
@@ -116,6 +128,7 @@ const CardContent = styled.div`
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     text-align: left;
   }
+
   .card.small {
     width: auto;
     padding: 0.5em;
@@ -153,6 +166,7 @@ const CardContent = styled.div`
     color: #4b3e91;
     font-weight: bold;
   }
+
   .card .value.small {
     font-size: 1em;
   }
@@ -161,9 +175,11 @@ const CardContent = styled.div`
     .card {
       flex: 1 0 45%;
     }
+
     .card .value {
       font-size: 1.5em;
     }
+
     .card .label {
       font-size: 0.8em;
     }
@@ -191,6 +207,12 @@ const CardContent = styled.div`
       margin-top: 1em;
     }
   }
+`;
+
+const UpdatingText = styled.p`
+  font-size: 0.85em !important;
+  margin: 0 0 6px !important;
+  color: #666 !important;
 `;
 
 /**
@@ -221,16 +243,22 @@ const ToggleButton = styled.button`
  * @param {Object} props - The component props.
  * @param {string} props.visualisationName - The name of the visualisation.
  * @param {string} [props.cardName] - Optional name for the card.
- * @param {Function} [props.onUpdate] - Optional function to call when the card updates.
+ * @param {Function} [props.onUpdate] - Backwards-compatible function to call when the card first becomes visible.
+ * @param {Function} [props.onFirstVisible] - Function to call when the card first becomes visible.
+ * @param {Object} props.data - Data used by the card.
+ * @param {boolean} props.isLoading - Whether this is the initial loading state.
+ * @param {boolean} props.isUpdating - Whether data is refreshing after first hydration.
  * @returns {JSX.Element|null} The rendered CalloutCardVisualisation component.
  */
-export const CalloutCardVisualisation = ({ 
-  visualisationName, 
-  cardName, 
-  onUpdate, 
-  data, 
-  isLoading, 
-  hideHandleOnMobile = false, 
+export const CalloutCardVisualisation = ({
+  visualisationName,
+  cardName,
+  onUpdate,
+  onFirstVisible,
+  data,
+  isLoading,
+  isUpdating = false,
+  hideHandleOnMobile = false,
   onVisibilityChange,
   recordSelector = null,
   toggleVisibility: externalToggleVisibility = null,
@@ -239,16 +267,20 @@ export const CalloutCardVisualisation = ({
   const { state } = useContext(MapContext);
   const visualisation = state.visualisations[visualisationName];
   const buttonRef = useRef(null);
+  const contentRef = useRef(null);
+  const hasFiredFirstVisibleRef = useRef(false);
 
   const colorsList = useMemo(() => {
     if (typeof getAllColors === "function") return getAllColors();
-    return ["#A0CA2A", "#E97132", "#7317DE", "#6D6875", "#3A86FF"]; // fallback
+
+    return ["#A0CA2A", "#E97132", "#7317DE", "#6D6875", "#3A86FF"];
   }, [getAllColors]);
 
   // Do not render the card if no data is available,
   // or if the data is an empty object,
   // or if every value in the data dictionary is nullish.
   let hasDataShouldRender = true;
+
   if (
     !data ||
     Object.keys(data).length === 0 ||
@@ -263,16 +295,34 @@ export const CalloutCardVisualisation = ({
 
   useEffect(() => {
     if (onVisibilityChange) onVisibilityChange(actuallyVisible);
+
     return () => {
       if (onVisibilityChange) onVisibilityChange(false);
     };
   }, [actuallyVisible, onVisibilityChange]);
 
+  // Effect to (for example) shoot to top of the list if first render
+  useEffect(() => {
+    if (!actuallyVisible) return;
+    if (hasFiredFirstVisibleRef.current) return;
+
+    hasFiredFirstVisibleRef.current = true;
+
+    if (typeof onFirstVisible === "function") {
+      onFirstVisible();
+    }
+
+    // Backwards compatibility: older parents may still pass onUpdate.
+    // Fire it once on first visible render rather than on every data update.
+    if (typeof onUpdate === "function") {
+      onUpdate();
+    }
+  }, [actuallyVisible, onFirstVisible, onUpdate]);
+
   // Slide-in: start hidden and slide to visible once the card truly has content.
   const [isVisible, setIsVisible] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const showHandle = !hideHandleOnMobile;
-  const contentRef = useRef(null);
 
   // Trigger initial slide-in when the card first becomes actually visible
   useEffect(() => {
@@ -297,6 +347,7 @@ export const CalloutCardVisualisation = ({
     } else {
       setIsVisible((v) => !v);
     }
+
     setIsHovered(false);
   };
 
@@ -305,16 +356,20 @@ export const CalloutCardVisualisation = ({
     return formatNumber(Number(value)) + unit;
   }, []);
 
-  let customFormattingFunctions = {
-    ...(visualisation.customFormattingFunctions || {}),
-    formatNumberWithUnit,
-  };
+  const customFormattingFunctions = useMemo(
+    () => ({
+      ...(visualisation.customFormattingFunctions || {}),
+      formatNumberWithUnit,
+    }),
+    [visualisation.customFormattingFunctions, formatNumberWithUnit]
+  );
 
-  // Batch compute the sanitized HTML and dynamic title together to avoid multi-step updates
+  // Batch compute the sanitised HTML and dynamic title together to avoid multi-step updates
   const { sanitizedHtml, safeDynamicTitle } = useMemo(() => {
     if (!data) {
       return { sanitizedHtml: "", safeDynamicTitle: "" };
     }
+
     const htmlFromFragment = visualisation.htmlFragment
       ? DOMPurify.sanitize(
           replacePlaceholders(visualisation.htmlFragment, data, {
@@ -342,63 +397,52 @@ export const CalloutCardVisualisation = ({
     customFormattingFunctions,
   ]);
 
-  // Keep a stable reference to onUpdate so it doesn't churn the effect deps
-  const onUpdateRef = useRef(onUpdate);
-  useEffect(() => {
-    onUpdateRef.current = onUpdate;
-  }, [onUpdate]);
+  const renderHandle = () =>
+    showHandle ? (
+      <>
+        <ToggleButton
+          ref={buttonRef}
+          $isVisible={isVisible}
+          onClick={toggleVisibility}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          aria-label={isVisible ? `Hide ${cardName || "Card"}` : `Show ${cardName || "Card"}`}
+        >
+          {isVisible ? (
+            <ChevronRightIcon style={{ width: "20px", height: "20px" }} />
+          ) : (
+            <ChevronLeftIcon style={{ width: "20px", height: "20px" }} />
+          )}
+        </ToggleButton>
 
-  // Call onUpdate to trigger the reordering of cards on a new request
-  useEffect(() => {
-    if (isLoading) return;
-    if (!hasDataShouldRender) return;
-    if (typeof onUpdateRef.current !== "function") return;
+        <Hovertip
+          isVisible={isHovered}
+          displayText={
+            isVisible
+              ? `Hide ${cardName || "Card"}`
+              : `Show ${cardName || "Card"}`
+          }
+          side="left"
+          refElement={buttonRef}
+          offset={5}
+        />
+      </>
+    ) : null;
 
-    onUpdateRef.current();
-  }, [data, visualisation?.htmlFragment, visualisation?.cardTitle, isLoading, hasDataShouldRender]);
-  
-
-  // Loading shell (kept mounted for initial slide-in once data arrives)
+  // Loading shell: initial load only. After hydration, BaseCalloutCardVisualisation
+  // keeps previous data visible and sends isUpdating instead.
   if (isLoading) {
     return (
-      <>
-        <ParentContainer $isVisible={isVisible}>
-          <CardContainer $isVisible={isVisible}>
-            <CardTitle>Loading...</CardTitle>
-            <CardContent>
-              <h3>Loading...</h3>
-            </CardContent>
-          </CardContainer>
-          {showHandle && (
-            <>
-              <ToggleButton
-                ref={buttonRef}
-                $isVisible={isVisible}
-                onClick={toggleVisibility}
-                onMouseEnter={() => setIsHovered(true)}
-                onMouseLeave={() => setIsHovered(false)}
-              >
-                {isVisible ? (
-                  <ChevronRightIcon style={{ width: "20px", height: "20px" }} />
-                ) : (
-                  <ChevronLeftIcon style={{ width: "20px", height: "20px" }} />
-                )}
-              </ToggleButton>
-              <Hovertip
-                isVisible={isHovered}
-                displayText={
-                  isVisible
-                    ? `Hide ${cardName || "Card"}`
-                    : `Show ${cardName || "Card"}`
-                }
-                side="left"
-                refElement={buttonRef}
-                offset={5}
-              />
-            </>
-          )}
-        </ParentContainer>
-      </>
+      <ParentContainer $isVisible={isVisible}>
+        <CardContainer $isVisible={isVisible}>
+          <CardTitle>Loading...</CardTitle>
+          <CardContent>
+            <h3>Loading...</h3>
+          </CardContent>
+        </CardContainer>
+
+        {renderHandle()}
+      </ParentContainer>
     );
   }
 
@@ -411,6 +455,15 @@ export const CalloutCardVisualisation = ({
       <ParentContainer $isVisible={isVisible}>
         <CardContainer $isVisible={isVisible}>
           <CardTitle>{cardName}</CardTitle>
+
+          {isUpdating && (
+            <CardContent>
+              <UpdatingText>Updating…</UpdatingText>
+            </CardContent>
+          )}
+
+          {recordSelector}
+
           {!hasDataShouldRender ? (
             <CardContent>
               <WarningBox text="No data available for selection" />
@@ -423,11 +476,11 @@ export const CalloutCardVisualisation = ({
                     ...(data.mainValues || {}),
                     ...data,
                   };
-                  const html = replacePlaceholders(
-                    item.fragment,
-                    mergedData,
-                    { customFunctions: customFormattingFunctions }
-                  );
+
+                  const html = replacePlaceholders(item.fragment, mergedData, {
+                    customFunctions: customFormattingFunctions,
+                  });
+
                   return (
                     <CardContent
                       key={idx}
@@ -436,31 +489,35 @@ export const CalloutCardVisualisation = ({
                       }}
                     />
                   );
-                } else {
-                  const allGraphs = Object.entries(data)
-                    .filter(([key, obj]) => obj && obj.type !== undefined)
-                    .map(([key, obj]) => ({ key, ...obj }));
-                  // Association of networks has a colour
-                  const networkColorMap = {};
-                  let colorIdx = 0;
-                  allGraphs.forEach((chart) => {
-                    if (
-                      chart.type === "multiple_bar" &&
-                      Array.isArray(chart.values)
-                    ) {
-                      chart.values.forEach((obj) => {
-                        const network = obj.network;
-                        if (network && !(network in networkColorMap)) {
-                          networkColorMap[network] =
-                            colorsList[colorIdx % colorsList.length];
-                          colorIdx++;
-                        }
-                      });
-                    }
-                  });
-                  return allGraphs.map((chart, idx) => {
-                    let configs;
-                    let chartData;
+                }
+
+                const allGraphs = Object.entries(data)
+                  .filter(([key, obj]) => obj && obj.type !== undefined)
+                  .map(([key, obj]) => ({ key, ...obj }));
+                // Association of networks has a colour
+                const networkColorMap = {};
+                let colorIdx = 0;
+
+                allGraphs.forEach((chart) => {
+                  if (
+                    chart.type === "multiple_bar" &&
+                    Array.isArray(chart.values)
+                  ) {
+                    chart.values.forEach((obj) => {
+                      const network = obj.network;
+
+                      if (network && !(network in networkColorMap)) {
+                        networkColorMap[network] =
+                          colorsList[colorIdx % colorsList.length];
+                        colorIdx++;
+                      }
+                    });
+                  }
+                });
+
+                return allGraphs.map((chart, chartIdx) => {
+                  let configs;
+                  let chartData;
 
                     configs = {
                       type: chart.type,
@@ -474,38 +531,40 @@ export const CalloutCardVisualisation = ({
                       colors: networkColorMap
                     };
 
-                    // Dynamic title for ranking charts
-                    if (
-                      (chart.type === "ranking" &&
-                        visualisation.queryParams?.dataTypeName?.value !==
-                          undefined) ||
-                      null
-                    ) {
-                      configs.title =
-                        "Top 5 by " +
-                        visualisation.queryParams.dataTypeName.value;
-                    }
+                  // Dynamic title for ranking charts
+                  if (
+                    (chart.type === "ranking" &&
+                      visualisation.queryParams?.dataTypeName?.value !==
+                        undefined) ||
+                    null
+                  ) {
+                    configs.title =
+                      "Top 5 by " +
+                      visualisation.queryParams.dataTypeName.value;
+                  }
 
-                    if (chart.type === "multiple_bar") {
-                      // Categories = all 'name'
-                      const categories = [
-                        ...new Set(chart.values.map((obj) => obj.name)),
-                      ];
-                      // Series = all networks
-                      const series = [
-                        ...new Set(chart.values.map((obj) => obj.network)),
-                      ];
+                  if (chart.type === "multiple_bar") {
+                    // Categories = all 'name'
+                    const categories = [
+                      ...new Set(chart.values.map((obj) => obj.name)),
+                    ];
+                    // Series = all networks
+                    const series = [
+                      ...new Set(chart.values.map((obj) => obj.network)),
+                    ];
 
-                      // Data formatted for grouped bars
-                      chartData = categories.map((cat) => {
-                        const entry = { label: cat };
-                        chart.values.forEach((obj) => {
-                          if (obj.name === cat) {
-                            entry[obj.network] = obj.columnValue;
-                          }
-                        });
-                        return entry;
+                    // Data formatted for grouped bars
+                    chartData = categories.map((cat) => {
+                      const entry = { label: cat };
+
+                      chart.values.forEach((obj) => {
+                        if (obj.name === cat) {
+                          entry[obj.network] = obj.columnValue;
+                        }
                       });
+
+                      return entry;
+                    });
 
                       configs.columns = series.map((network) => ({
                         key: network,
@@ -521,138 +580,92 @@ export const CalloutCardVisualisation = ({
                         label: obj.name,
                       }));
 
-                      chartData = chart.values.reduce((acc, obj) => {
-                        acc[obj.name] = obj.columnValue;
+                    chartData = chart.values.reduce((acc, obj) => {
+                      acc[obj.name] = obj.columnValue;
+                      return acc;
+                    }, {});
+                    // ranks if necessary
+                    const hasRank = chart.values.some(
+                      (obj) => obj.rank !== undefined
+                    );
+
+                    if (hasRank) {
+                      configs.ranks = chart.values.reduce((acc, obj) => {
+                        if (obj.rank !== undefined) {
+                          acc[obj.name] = obj.rank;
+                        }
+
                         return acc;
                       }, {});
-
-                      // ranks if necessary
-                      const hasRank = chart.values.some(
-                        (obj) => obj.rank !== undefined
-                      );
-                      if (hasRank) {
-                        configs.ranks = chart.values.reduce((acc, obj) => {
-                          if (obj.rank !== undefined) {
-                            acc[obj.name] = obj.rank;
-                          }
-                          return acc;
-                        }, {});
-                      }
                     }
+                  }
 
-                    return (
-                      <CardContent key={idx}>
-                        <ChartRenderer
-                          charts={[configs]}
-                          data={chartData}
-                          formatters={customFormattingFunctions}
-                          barHeight={225}
-                        />
-                      </CardContent>
-                    );
-                  });
-                }
+                  return (
+                    <CardContent key={`${idx}-${chartIdx}`}>
+                      <ChartRenderer
+                        charts={[configs]}
+                        data={chartData}
+                        formatters={customFormattingFunctions}
+                        barHeight={225}
+                      />
+                    </CardContent>
+                  );
+                });
               })}
             </>
           )}
         </CardContainer>
-        {showHandle && (
-          <>
-            <ToggleButton
-              ref={buttonRef}
-              $isVisible={isVisible}
-              onClick={toggleVisibility}
-              onMouseEnter={() => setIsHovered(true)}
-              onMouseLeave={() => setIsHovered(false)}
-            >
-              {isVisible ? (
-                <ChevronRightIcon style={{ width: "20px", height: "20px" }} />
-              ) : (
-                <ChevronLeftIcon style={{ width: "20px", height: "20px" }} />
-              )}
-            </ToggleButton>
-            <Hovertip
-              isVisible={isHovered}
-              displayText={
-                isVisible
-                  ? `Hide ${cardName || "Card"}`
-                  : `Show ${cardName || "Card"}`
-              }
-              side="left"
-              refElement={buttonRef}
-              offset={5}
-            />
-          </>
-        )}
+
+        {renderHandle()}
       </ParentContainer>
     );
   }
 
   // Render the card with dynamic content
   return (
-    <>
-      <ParentContainer $isVisible={isVisible}>
-        <CardContainer $isVisible={isVisible}>
-          <CardTitle>{cardName}</CardTitle>
-          {recordSelector}
-          {!hasDataShouldRender ? (
-            <CardContent>
-              <WarningBox text="No data available for selection" />
-            </CardContent>
-          ) : (
-            <>
-              {/* Render charts if provided */}
-              {Array.isArray(visualisation.charts) &&
-                visualisation.charts.length > 0 && (
-                  <CardContent>
-                    {safeDynamicTitle ? <h2>{safeDynamicTitle}</h2> : null}
-                    <ChartRenderer
-                      charts={visualisation.charts}
-                      data={data}
-                      formatters={customFormattingFunctions}
-                      barHeight={225}
-                    />
-                  </CardContent>
-                )}
-              {/* Render HTML fragment if provided (after charts to match nssec config concatenation) */}
-              {sanitizedHtml && (
-                <CardContent
-                  ref={contentRef}
-                  dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
-                />
-              )}
-            </>
-          )}
-        </CardContainer>
-        {showHandle && (
+    <ParentContainer $isVisible={isVisible}>
+      <CardContainer $isVisible={isVisible}>
+        <CardTitle>{cardName}</CardTitle>
+
+        {isUpdating && (
+          <CardContent>
+            <UpdatingText>Updating…</UpdatingText>
+          </CardContent>
+        )}
+
+        {recordSelector}
+
+        {!hasDataShouldRender ? (
+          <CardContent>
+            <WarningBox text="No data available for selection" />
+          </CardContent>
+        ) : (
           <>
-            <ToggleButton
-              ref={buttonRef}
-              $isVisible={isVisible}
-              onClick={toggleVisibility}
-              onMouseEnter={() => setIsHovered(true)}
-              onMouseLeave={() => setIsHovered(false)}
-            >
-              {isVisible ? (
-                <ChevronRightIcon style={{ width: "20px", height: "20px" }} />
-              ) : (
-                <ChevronLeftIcon style={{ width: "20px", height: "20px" }} />
+            {/* Render charts if provided */}
+            {Array.isArray(visualisation.charts) &&
+              visualisation.charts.length > 0 && (
+                <CardContent>
+                  {safeDynamicTitle ? <h2>{safeDynamicTitle}</h2> : null}
+                  <ChartRenderer
+                    charts={visualisation.charts}
+                    data={data}
+                    formatters={customFormattingFunctions}
+                    barHeight={225}
+                  />
+                </CardContent>
               )}
-            </ToggleButton>
-            <Hovertip
-              isVisible={isHovered}
-              displayText={
-                isVisible
-                  ? `Hide ${cardName || "Card"}`
-                  : `Show ${cardName || "Card"}`
-              }
-              side="left"
-              refElement={buttonRef}
-              offset={5}
-            />
+
+            {sanitizedHtml && (
+              <CardContent
+                ref={contentRef}
+                dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+              />
+            )}
           </>
         )}
-      </ParentContainer>
-    </>
+      </CardContainer>
+
+      {renderHandle()}
+    </ParentContainer>
   );
 };

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.test.jsx
@@ -263,6 +263,18 @@ describe("Tests when useFetchVisualisationData return isLoading", () => {
     expect(h2Element).toBeInTheDocument();
     expect(h3Element).toBeInTheDocument();
   });
+  it("hides the desktop toggle while loading in mobile stack mode", () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <MapContext.Provider value={mockMapContext}>
+          <CalloutCardVisualisation {...propsWithLoading} hideHandleOnMobile />
+        </MapContext.Provider>
+      </ThemeProvider>
+    );
+
+    expect(screen.getAllByText("Loading...")).toHaveLength(2);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
   it("Click on the toggle button", async () => {
     render(
       <ThemeProvider theme={theme}>
@@ -280,6 +292,26 @@ describe("Tests when useFetchVisualisationData return isLoading", () => {
     await waitFor(() => {
       expect(screen.getByText("ChevronLeft")).toBeInTheDocument();
     });
+  });
+});
+
+describe("Tests for mobile stacked cards", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders loaded card content without the desktop toggle", () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <MapContext.Provider value={mockMapContext}>
+          <CalloutCardVisualisation {...props} hideHandleOnMobile />
+        </MapContext.Provider>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText("cardName")).toBeInTheDocument();
+    expect(screen.getByText("1-label-location_id-text_with_placeholders")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 });
 

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { CalloutCardVisualisation } from "./CalloutCardVisualisation";
 import { MapContext } from "contexts";
 import userEvent from "@testing-library/user-event";
@@ -188,6 +188,56 @@ describe("Tests when useFetchVisualisationData return valid values", () => {
     await user.click(screen.getByRole("button", { name: /show cardName/i }));
 
     expect(onCardUpdateAcknowledged).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the same expiry timestamp for the update callback and local badge", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const onCardUpdated = jest.fn();
+
+    const { rerender } = render(
+      <ThemeProvider theme={theme}>
+        <MapContext.Provider value={mockMapContext}>
+          <CalloutCardVisualisation {...props} onCardUpdated={onCardUpdated} />
+        </MapContext.Provider>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("ChevronRight")).toBeInTheDocument();
+    });
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <MapContext.Provider value={mockMapContext}>
+          <CalloutCardVisualisation
+            {...props}
+            data={{ ...props.data, label: "updated label" }}
+            onCardUpdated={onCardUpdated}
+          />
+        </MapContext.Provider>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(onCardUpdated).toHaveBeenCalledWith({
+        autoClearAt: Date.now() + 2800,
+        timeoutMs: 2800,
+      });
+      expect(screen.getByRole("status")).toHaveTextContent("Updated");
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(2799);
+    });
+    expect(screen.getByRole("status")).toHaveTextContent("Updated");
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    jest.useRealTimers();
   });
 });
 

--- a/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/CalloutCards/CalloutCardVisualisation.test.jsx
@@ -123,6 +123,72 @@ describe("Tests when useFetchVisualisationData return valid values", () => {
     // customFormattingFunctions function to have been called
     expect(props.onUpdate).toHaveBeenCalled();
   });
+
+  it("reports visibility when renderable data is available", async () => {
+    const onVisibilityChange = jest.fn();
+
+    render(
+      <ThemeProvider theme={theme}>
+        <MapContext.Provider value={mockMapContext}>
+          <CalloutCardVisualisation {...props} onVisibilityChange={onVisibilityChange} />
+        </MapContext.Provider>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(onVisibilityChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it("shows an update badge for changed data and acknowledges it when opened", async () => {
+    const onCardUpdated = jest.fn();
+    const onCardUpdateAcknowledged = jest.fn();
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <ThemeProvider theme={theme}>
+        <MapContext.Provider value={mockMapContext}>
+          <CalloutCardVisualisation
+            {...props}
+            onCardUpdated={onCardUpdated}
+            onCardUpdateAcknowledged={onCardUpdateAcknowledged}
+          />
+        </MapContext.Provider>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("ChevronRight")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /hide cardName/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("ChevronLeft")).toBeInTheDocument();
+    });
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <MapContext.Provider value={mockMapContext}>
+          <CalloutCardVisualisation
+            {...props}
+            data={{ ...props.data, label: "updated label" }}
+            onCardUpdated={onCardUpdated}
+            onCardUpdateAcknowledged={onCardUpdateAcknowledged}
+          />
+        </MapContext.Provider>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(onCardUpdated).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("status")).toHaveTextContent("Updated");
+    });
+
+    await user.click(screen.getByRole("button", { name: /show cardName/i }));
+
+    expect(onCardUpdateAcknowledged).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("Tests when useFetchVisualisationData return isLoading", () => {
@@ -178,13 +244,15 @@ describe("Tests when isLoading is false and without data", () => {
     jest.clearAllMocks();
   });
   it("Check the empty returned", () => {
+    const onVisibilityChange = jest.fn();
     const { container } = render(
       <ThemeProvider theme={theme}>
         <MapContext.Provider value={mockMapContext}>
-          <CalloutCardVisualisation {...propsEmpty} />
+          <CalloutCardVisualisation {...propsEmpty} onVisibilityChange={onVisibilityChange} />
         </MapContext.Provider>
       </ThemeProvider>
     );
     expect(container).toBeEmptyDOMElement();
+    expect(onVisibilityChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
+++ b/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
@@ -26,7 +26,7 @@ export const VisualisationManager = ({
   maps,
   ...props
 }) => {
-  const sidebarIsOpen = props.sidebarIsOpen
+  const sidebarIsOpen = props.sidebarIsOpen;
   // Convert visualisationConfigs object to an array of entries
   const visualisationEntries = Object.entries(visualisationConfigs);
   // Separate visualizations by type
@@ -49,7 +49,9 @@ export const VisualisationManager = ({
 
   const visibleMapRef = useRef({});
   const firstVisibleCardsRef = useRef(new Set());
+
   const [visibleCount, setVisibleCount] = useState(0);
+  const [updatedCardNames, setUpdatedCardNames] = useState(() => new Set());
 
 /**
  * Track visibility for a single card and refresh the aggregate count.
@@ -82,6 +84,32 @@ export const VisualisationManager = ({
     [moveCardToTop]
   );
 
+  const handleCardUpdated = useCallback((name) => {
+    setUpdatedCardNames((prev) => {
+      const next = new Set(prev);
+      next.add(name);
+      return next;
+    });
+  }, []);
+
+  const clearUpdatedCardMarker = useCallback((name) => {
+    if (!name) return;
+
+    setUpdatedCardNames((prev) => {
+      if (!prev.has(name)) return prev;
+
+      const next = new Set(prev);
+      next.delete(name);
+      return next;
+    });
+  }, []);
+
+  const clearUpdatedCardMarkers = useCallback(() => {
+    setUpdatedCardNames(new Set());
+  }, []);
+
+  
+
   const showOnMobile = visibleCount > 0;
 
   // Update cardOrder when visualisationConfigs change AND on first card render
@@ -109,12 +137,22 @@ export const VisualisationManager = ({
         newOrder.includes(name)
       )
     );
+
+    setUpdatedCardNames((prev) => {
+      return new Set([...prev].filter((name) => newOrder.includes(name)));
+    });
   }, [visualisationConfigs]);
 
   return (
     <>
       {/* Render all calloutCard visualisations inside ScrollableContainer */}
-      <ScrollableContainer showOnMobile={showOnMobile} hideCardHandleOnMobile>
+      <ScrollableContainer
+        showOnMobile={showOnMobile}
+        hideCardHandleOnMobile
+        updatedCardNames={[...updatedCardNames]}
+        onUpdatedCardSeen={clearUpdatedCardMarker}
+        onUpdatedCardsClicked={clearUpdatedCardMarkers}
+      >
         {cardOrder.map((name) => {
           const config = calloutCardConfigByName[name];
 
@@ -131,6 +169,8 @@ export const VisualisationManager = ({
               onVisibilityChange={(isVisible) =>
                 handleCardVisibility(name, isVisible)
               }
+              onCardUpdated={() => handleCardUpdated(name)}
+              onCardUpdateAcknowledged={() => clearUpdatedCardMarker(name)}
             />
           );
         })}

--- a/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
+++ b/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MapVisualisation } from "./MapVisualisation";
 import { ScrollableContainer } from "Components";
 import { BaseCalloutCardVisualisation } from "./CalloutCards/BaseCalloutCardVisualisation";
 
+const UPDATE_MARKER_TIMEOUT_MS = 2800;
 
 /**
  * VisualisationManager component that renders the appropriate visualizations
@@ -51,7 +52,12 @@ export const VisualisationManager = ({
   const firstVisibleCardsRef = useRef(new Set());
 
   const [visibleCount, setVisibleCount] = useState(0);
-  const [updatedCardNames, setUpdatedCardNames] = useState(() => new Set());
+  const [updatedCardExpiries, setUpdatedCardExpiries] = useState({});
+
+  const updatedCardNames = useMemo(
+    () => Object.keys(updatedCardExpiries),
+    [updatedCardExpiries]
+  );
 
   /**
    * Tracks whether a callout card currently has renderable data and refreshes
@@ -96,14 +102,26 @@ export const VisualisationManager = ({
 
   /**
    * Marks a card as updated until the card or stack-level marker is acknowledged.
+   * Stores each card's fixed auto-clear expiry so unrelated interactions do not
+   * restart existing card timers.
    *
    * @param {string} name - Visualisation/card identifier.
+   * @param {Object} [updateInfo] - Timing details from the updated card.
+   * @param {number} [updateInfo.autoClearAt] - Epoch time when the marker should clear.
    */
-  const handleCardUpdated = useCallback((name) => {
-    setUpdatedCardNames((prev) => {
-      const next = new Set(prev);
-      next.add(name);
-      return next;
+  const handleCardUpdated = useCallback((name, updateInfo = {}) => {
+    const autoClearAt =
+      typeof updateInfo.autoClearAt === "number"
+        ? updateInfo.autoClearAt
+        : Date.now() + UPDATE_MARKER_TIMEOUT_MS;
+
+    setUpdatedCardExpiries((prev) => {
+      if (prev[name] === autoClearAt) return prev;
+
+      return {
+        ...prev,
+        [name]: autoClearAt,
+      };
     });
   }, []);
 
@@ -115,11 +133,11 @@ export const VisualisationManager = ({
   const clearUpdatedCardMarker = useCallback((name) => {
     if (!name) return;
 
-    setUpdatedCardNames((prev) => {
-      if (!prev.has(name)) return prev;
+    setUpdatedCardExpiries((prev) => {
+      if (!(name in prev)) return prev;
 
-      const next = new Set(prev);
-      next.delete(name);
+      const next = { ...prev };
+      delete next[name];
       return next;
     });
   }, []);
@@ -128,7 +146,7 @@ export const VisualisationManager = ({
    * Clears all stack-level update markers after the user clicks the update hint.
    */
   const clearUpdatedCardMarkers = useCallback(() => {
-    setUpdatedCardNames(new Set());
+    setUpdatedCardExpiries({});
   }, []);
 
   const showOnMobile = visibleCount > 0;
@@ -162,8 +180,10 @@ export const VisualisationManager = ({
       )
     );
 
-    setUpdatedCardNames((prev) => {
-      return new Set([...prev].filter((name) => newOrder.includes(name)));
+    setUpdatedCardExpiries((prev) => {
+      return Object.fromEntries(
+        Object.entries(prev).filter(([name]) => newOrder.includes(name))
+      );
     });
   }, [visualisationConfigs]);
 
@@ -173,7 +193,8 @@ export const VisualisationManager = ({
       <ScrollableContainer
         showOnMobile={showOnMobile}
         hideCardHandleOnMobile
-        updatedCardNames={[...updatedCardNames]}
+        updatedCardNames={updatedCardNames}
+        updatedCardExpiresAtByName={updatedCardExpiries}
         onUpdatedCardSeen={clearUpdatedCardMarker}
         onUpdatedCardsClicked={clearUpdatedCardMarkers}
       >
@@ -193,7 +214,7 @@ export const VisualisationManager = ({
               onVisibilityChange={(isVisible) =>
                 handleCardVisibility(name, isVisible)
               }
-              onCardUpdated={() => handleCardUpdated(name)}
+              onCardUpdated={(updateInfo) => handleCardUpdated(name, updateInfo)}
               onCardUpdateAcknowledged={() => clearUpdatedCardMarker(name)}
             />
           );

--- a/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
+++ b/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { MapVisualisation } from "./MapVisualisation";
 import { ScrollableContainer } from "Components";
 import { BaseCalloutCardVisualisation } from "./CalloutCards/BaseCalloutCardVisualisation";
@@ -7,6 +7,12 @@ import { BaseCalloutCardVisualisation } from "./CalloutCards/BaseCalloutCardVisu
 /**
  * VisualisationManager component that renders the appropriate visualizations
  * based on the types specified in the visualisation configurations.
+ *
+ * Behaviour:
+ * - Callout card order is stable during normal data updates.
+ * - A callout card moves to the top only once: the first time it becomes visible
+ *   with real data.
+ * - Mobile summary visibility is tracked via onVisibilityChange.
  *
  * @param {Object} props - The component props.
  * @param {Object} props.visualisationConfigs - Object of configuration objects for the visualizations.
@@ -42,8 +48,9 @@ export const VisualisationManager = ({
   );
 
   const visibleMapRef = useRef({});
+  const firstVisibleCardsRef = useRef(new Set());
   const [visibleCount, setVisibleCount] = useState(0);
-  
+
 /**
  * Track visibility for a single card and refresh the aggregate count.
  * @name handleCardVisibility
@@ -52,34 +59,57 @@ export const VisualisationManager = ({
  * @param {string} name - The visualisation/card identifier.
  * @param {boolean} isVisible - Whether the card is currently visible.
  */
-  const handleCardVisibility = (name, isVisible) => {
+  const handleCardVisibility = useCallback((name, isVisible) => {
     const next = { ...visibleMapRef.current, [name]: !!isVisible };
     visibleMapRef.current = next;
     setVisibleCount(Object.values(next).filter(Boolean).length);
-  };
+  }, []);
+
+  const moveCardToTop = useCallback((name) => {
+    setCardOrder((prevOrder) => [
+      name,
+      ...prevOrder.filter((existingName) => existingName !== name),
+    ]);
+  }, []);
+
+  const handleCardFirstVisible = useCallback(
+    (name) => {
+      if (firstVisibleCardsRef.current.has(name)) return;
+
+      firstVisibleCardsRef.current.add(name);
+      moveCardToTop(name);
+    },
+    [moveCardToTop]
+  );
 
   const showOnMobile = visibleCount > 0;
 
-  // Update cardOrder when visualisationConfigs change
+  // Update cardOrder when visualisationConfigs change AND on first card render
   useEffect(() => {
     const newOrder = calloutCardVisualisations.map(([name]) => name);
-    setCardOrder((prevOrder) => {
-      // Keep existing order as much as possible
-      const newPrevOrder = prevOrder.filter((name) => newOrder.includes(name));
-      const addedNames = newOrder.filter(
-        (name) => !newPrevOrder.includes(name)
-      );
-      return [...newPrevOrder, ...addedNames];
-    });
-  }, [visualisationConfigs]);
 
-  // Handler when a card is updated
-  const handleCardUpdate = (updatedName) => {
-    setCardOrder((prevOrder) => [
-      updatedName,
-      ...prevOrder.filter((name) => name !== updatedName),
-    ]);
-  };
+    setCardOrder((prevOrder) => {
+      const retained = prevOrder.filter((name) => newOrder.includes(name));
+      const addedNames = newOrder.filter((name) => !retained.includes(name));
+      return [...retained, ...addedNames];
+    });
+
+    visibleMapRef.current = Object.fromEntries(
+      Object.entries(visibleMapRef.current).filter(([name]) =>
+        newOrder.includes(name)
+      )
+    );
+
+    setVisibleCount(
+      Object.values(visibleMapRef.current).filter(Boolean).length
+    );
+
+    firstVisibleCardsRef.current = new Set(
+      [...firstVisibleCardsRef.current].filter((name) =>
+        newOrder.includes(name)
+      )
+    );
+  }, [visualisationConfigs]);
 
   return (
     <>
@@ -87,14 +117,20 @@ export const VisualisationManager = ({
       <ScrollableContainer showOnMobile={showOnMobile} hideCardHandleOnMobile>
         {cardOrder.map((name) => {
           const config = calloutCardConfigByName[name];
+
+          if (!config) return null;
+
           return (
             <BaseCalloutCardVisualisation
               type={config.cardType || "small"}
               key={name}
               visualisationName={name}
               cardName={config.cardName || name}
-              onUpdate={() => handleCardUpdate(name)}
               sidebarIsOpen={sidebarIsOpen}
+              onFirstVisible={() => handleCardFirstVisible(name)}
+              onVisibilityChange={(isVisible) =>
+                handleCardVisibility(name, isVisible)
+              }
             />
           );
         })}

--- a/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
+++ b/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
@@ -149,7 +149,7 @@ export const VisualisationManager = ({
     setUpdatedCardExpiries({});
   }, []);
 
-  const showOnMobile = visibleCount > 0;
+  const showOnMobile = calloutCardVisualisations.length > 0;
 
   /**
    * Keeps card order, visibility, first-visible tracking, and update markers in

--- a/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
+++ b/packages/vis-core/src/Components/MapLayout/VisualisationManager.jsx
@@ -53,20 +53,24 @@ export const VisualisationManager = ({
   const [visibleCount, setVisibleCount] = useState(0);
   const [updatedCardNames, setUpdatedCardNames] = useState(() => new Set());
 
-/**
- * Track visibility for a single card and refresh the aggregate count.
- * @name handleCardVisibility
- * @function
- * @global
- * @param {string} name - The visualisation/card identifier.
- * @param {boolean} isVisible - Whether the card is currently visible.
- */
+  /**
+   * Tracks whether a callout card currently has renderable data and refreshes
+   * the aggregate mobile-summary visibility count.
+   *
+   * @param {string} name - Visualisation/card identifier.
+   * @param {boolean} isVisible - Whether the card has renderable data.
+   */
   const handleCardVisibility = useCallback((name, isVisible) => {
     const next = { ...visibleMapRef.current, [name]: !!isVisible };
     visibleMapRef.current = next;
     setVisibleCount(Object.values(next).filter(Boolean).length);
   }, []);
 
+  /**
+   * Moves a card to the front of the rendered callout stack.
+   *
+   * @param {string} name - Visualisation/card identifier.
+   */
   const moveCardToTop = useCallback((name) => {
     setCardOrder((prevOrder) => [
       name,
@@ -74,6 +78,12 @@ export const VisualisationManager = ({
     ]);
   }, []);
 
+  /**
+   * Moves a card once, when it first becomes visible with real data.
+   * Later data updates are surfaced as update markers instead of reordering.
+   *
+   * @param {string} name - Visualisation/card identifier.
+   */
   const handleCardFirstVisible = useCallback(
     (name) => {
       if (firstVisibleCardsRef.current.has(name)) return;
@@ -84,6 +94,11 @@ export const VisualisationManager = ({
     [moveCardToTop]
   );
 
+  /**
+   * Marks a card as updated until the card or stack-level marker is acknowledged.
+   *
+   * @param {string} name - Visualisation/card identifier.
+   */
   const handleCardUpdated = useCallback((name) => {
     setUpdatedCardNames((prev) => {
       const next = new Set(prev);
@@ -92,6 +107,11 @@ export const VisualisationManager = ({
     });
   }, []);
 
+  /**
+   * Clears one card's update marker after it has been seen or opened.
+   *
+   * @param {string} name - Visualisation/card identifier.
+   */
   const clearUpdatedCardMarker = useCallback((name) => {
     if (!name) return;
 
@@ -104,15 +124,19 @@ export const VisualisationManager = ({
     });
   }, []);
 
+  /**
+   * Clears all stack-level update markers after the user clicks the update hint.
+   */
   const clearUpdatedCardMarkers = useCallback(() => {
     setUpdatedCardNames(new Set());
   }, []);
 
-  
-
   const showOnMobile = visibleCount > 0;
 
-  // Update cardOrder when visualisationConfigs change AND on first card render
+  /**
+   * Keeps card order, visibility, first-visible tracking, and update markers in
+   * sync with the currently configured callout cards.
+   */
   useEffect(() => {
     const newOrder = calloutCardVisualisations.map(([name]) => name);
 

--- a/packages/vis-core/src/Components/MapLayout/VisualisationManager.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/VisualisationManager.test.jsx
@@ -15,11 +15,24 @@ jest.mock("maplibre-gl", () => ({
 }));
 
 jest.mock("./CalloutCards/BaseCalloutCardVisualisation", () => ({
-  BaseCalloutCardVisualisation: ({ visualisationName, cardName, onUpdate, type, sidebarIsOpen }) => {
+  BaseCalloutCardVisualisation: ({
+    visualisationName,
+    cardName,
+    onFirstVisible,
+    onVisibilityChange,
+    onCardUpdated,
+    onCardUpdateAcknowledged,
+    type,
+    sidebarIsOpen,
+  }) => {
     return (
-      <div data-testid="callout-card-visualisation">
+      <div data-testid="callout-card-visualisation" data-name={visualisationName}>
         Mock BaseCalloutCardVisualisation - {visualisationName} - {cardName} - {type} - {sidebarIsOpen}
-        <button onClick={onUpdate}>button: {cardName}</button>
+        <button onClick={onFirstVisible}>first visible: {cardName}</button>
+        <button onClick={() => onVisibilityChange(true)}>visible: {cardName}</button>
+        <button onClick={() => onVisibilityChange(false)}>hidden: {cardName}</button>
+        <button onClick={onCardUpdated}>updated: {cardName}</button>
+        <button onClick={onCardUpdateAcknowledged}>acknowledged: {cardName}</button>
       </div>
     );
   },
@@ -37,10 +50,21 @@ jest.mock("./MapVisualisation", () => ({
 }));
 
 jest.mock("Components", () => ({
-  ScrollableContainer: ({ children, showOnMobile, hideCardHandleOnMobile }) => {
+  ScrollableContainer: ({
+    children,
+    showOnMobile,
+    hideCardHandleOnMobile,
+    updatedCardNames = [],
+    onUpdatedCardsClicked,
+  }) => {
     return (
-      <div data-testid="scrollable-container">
+      <div
+        data-testid="scrollable-container"
+        data-show-on-mobile={showOnMobile.toString()}
+      >
         Mock ScrollableContainer - {showOnMobile.toString()} - {hideCardHandleOnMobile.toString()}
+        <span data-testid="updated-card-names">{updatedCardNames.join(",")}</span>
+        <button onClick={onUpdatedCardsClicked}>clear all updates</button>
         {children}
       </div>
     );
@@ -87,14 +111,80 @@ describe("Test to render a CalloutVisualisationCard", () => {
     expect(cardName).toBeInTheDocument();
     expect(cardName1).toBeInTheDocument();
   });
-  it("Click on the onUpdate button", async () => {
+  it("tracks visible cards for mobile summary visibility", async () => {
+    const user = userEvent.setup();
+
     render(
       <MapContext.Provider value={mockMapContext}>
         <VisualisationManager {...props} />
       </MapContext.Provider>
     );
-    const onUpdateButton = screen.getByText(/button: Test Card1/);
-    userEvent.click(onUpdateButton);
+    expect(screen.getByTestId("scrollable-container")).toHaveAttribute(
+      "data-show-on-mobile",
+      "false"
+    );
+
+    await user.click(screen.getByRole("button", { name: "visible: Test Card1" }));
+    expect(screen.getByTestId("scrollable-container")).toHaveAttribute(
+      "data-show-on-mobile",
+      "true"
+    );
+
+    await user.click(screen.getByRole("button", { name: "hidden: Test Card1" }));
+    expect(screen.getByTestId("scrollable-container")).toHaveAttribute(
+      "data-show-on-mobile",
+      "false"
+    );
+  });
+
+  it("moves a card to the top only the first time it becomes visible", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MapContext.Provider value={mockMapContext}>
+        <VisualisationManager {...props} />
+      </MapContext.Provider>
+    );
+
+    expect(screen.getAllByTestId("callout-card-visualisation").map((el) => el.dataset.name)).toEqual([
+      "calloutCard",
+      "calloutCard1",
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "first visible: Test Card1" }));
+    expect(screen.getAllByTestId("callout-card-visualisation").map((el) => el.dataset.name)).toEqual([
+      "calloutCard1",
+      "calloutCard",
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "first visible: Test Card1" }));
+    expect(screen.getAllByTestId("callout-card-visualisation").map((el) => el.dataset.name)).toEqual([
+      "calloutCard1",
+      "calloutCard",
+    ]);
+  });
+
+  it("tracks and clears updated card markers", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MapContext.Provider value={mockMapContext}>
+        <VisualisationManager {...props} />
+      </MapContext.Provider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "updated: Test Card1" }));
+    expect(screen.getByTestId("updated-card-names")).toHaveTextContent("calloutCard1");
+
+    await user.click(screen.getByRole("button", { name: "acknowledged: Test Card1" }));
+    expect(screen.getByTestId("updated-card-names")).toHaveTextContent("");
+
+    await user.click(screen.getByRole("button", { name: "updated: Test Card" }));
+    await user.click(screen.getByRole("button", { name: "updated: Test Card1" }));
+    expect(screen.getByTestId("updated-card-names")).toHaveTextContent("calloutCard,calloutCard1");
+
+    await user.click(screen.getByText("clear all updates"));
+    expect(screen.getByTestId("updated-card-names")).toHaveTextContent("");
   });
 });
 

--- a/packages/vis-core/src/Components/MapLayout/VisualisationManager.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/VisualisationManager.test.jsx
@@ -113,26 +113,24 @@ describe("Test to render a CalloutVisualisationCard", () => {
     expect(cardName).toBeInTheDocument();
     expect(cardName1).toBeInTheDocument();
   });
-  it("tracks visible cards for mobile summary visibility", async () => {
-    const user = userEvent.setup();
-
-    render(
+  it("sets show-on-mobile based on presence of configured cards", () => {
+    const { rerender } = render(
       <MapContext.Provider value={mockMapContext}>
         <VisualisationManager {...props} />
       </MapContext.Provider>
     );
     expect(screen.getByTestId("scrollable-container")).toHaveAttribute(
       "data-show-on-mobile",
-      "false"
-    );
-
-    await user.click(screen.getByRole("button", { name: "visible: Test Card1" }));
-    expect(screen.getByTestId("scrollable-container")).toHaveAttribute(
-      "data-show-on-mobile",
       "true"
     );
 
-    await user.click(screen.getByRole("button", { name: "hidden: Test Card1" }));
+    // Re-render with no cards
+    rerender(
+      <MapContext.Provider value={mockMapContext}>
+        <VisualisationManager {...props} visualisationConfigs={{}} />
+      </MapContext.Provider>
+    );
+    
     expect(screen.getByTestId("scrollable-container")).toHaveAttribute(
       "data-show-on-mobile",
       "false"

--- a/packages/vis-core/src/Components/MapLayout/VisualisationManager.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/VisualisationManager.test.jsx
@@ -55,6 +55,7 @@ jest.mock("Components", () => ({
     showOnMobile,
     hideCardHandleOnMobile,
     updatedCardNames = [],
+    updatedCardExpiresAtByName = {},
     onUpdatedCardsClicked,
   }) => {
     return (
@@ -64,6 +65,7 @@ jest.mock("Components", () => ({
       >
         Mock ScrollableContainer - {showOnMobile.toString()} - {hideCardHandleOnMobile.toString()}
         <span data-testid="updated-card-names">{updatedCardNames.join(",")}</span>
+        <span data-testid="updated-card-expiries">{JSON.stringify(updatedCardExpiresAtByName)}</span>
         <button onClick={onUpdatedCardsClicked}>clear all updates</button>
         {children}
       </div>
@@ -185,6 +187,31 @@ describe("Test to render a CalloutVisualisationCard", () => {
 
     await user.click(screen.getByText("clear all updates"));
     expect(screen.getByTestId("updated-card-names")).toHaveTextContent("");
+  });
+
+  it("preserves existing update expiry when another card updates", async () => {
+    const user = userEvent.setup();
+    let now = 0;
+    const nowSpy = jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    render(
+      <MapContext.Provider value={mockMapContext}>
+        <VisualisationManager {...props} />
+      </MapContext.Provider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "updated: Test Card" }));
+    expect(screen.getByTestId("updated-card-expiries")).toHaveTextContent(
+      JSON.stringify({ calloutCard: 2800 })
+    );
+
+    now = 1000;
+    await user.click(screen.getByRole("button", { name: "updated: Test Card1" }));
+    expect(screen.getByTestId("updated-card-expiries")).toHaveTextContent(
+      JSON.stringify({ calloutCard: 2800, calloutCard1: 3800 })
+    );
+
+    nowSpy.mockRestore();
   });
 });
 

--- a/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.jsx
+++ b/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.jsx
@@ -15,6 +15,14 @@ import { CARD_CONSTANTS } from "defaults";
 const { PADDING } = CARD_CONSTANTS;
 
 const MOBILE_Q = "(max-width: 900px)";
+const EMPTY_UPDATED_CARD_NAMES = [];
+
+/**
+ * Resolves the mobile media query from theme when supplied, with a local fallback.
+ *
+ * @param {Object} p - Styled-component props.
+ * @returns {string} CSS media query.
+ */
 const mobileMQ = (p) => p.theme?.mq?.mobile || MOBILE_Q;
 
 const StyledScrollableContainer = styled.div`
@@ -165,6 +173,12 @@ const Chevron = styled.span`
   margin-top: ${({ $direction }) => ($direction === "up" ? "3px" : "-3px")};
 `;
 
+/**
+ * Converts supported updated-card inputs into an array for rendering and lookup.
+ *
+ * @param {string[]|Set<string>} updatedCardNames - Updated card identifiers.
+ * @returns {string[]} Normalised card identifiers.
+ */
 const normaliseUpdatedNames = (updatedCardNames) => {
   if (!updatedCardNames) return [];
   if (updatedCardNames instanceof Set) return [...updatedCardNames];
@@ -200,7 +214,7 @@ export const ScrollableContainer = ({
   mobileBarColor,
   hideCardHandleOnMobile = true,
   showOnMobile = true,
-  updatedCardNames = [],
+  updatedCardNames = EMPTY_UPDATED_CARD_NAMES,
   onUpdatedCardSeen,
   onUpdatedCardsClicked,
   onOverflowHintClick,
@@ -229,6 +243,9 @@ export const ScrollableContainer = ({
 
   const [firstUpdatedCardName, setFirstUpdatedCardName] = useState(null);
 
+  /**
+   * Clears the delayed "updated card seen" acknowledgement timer.
+   */
   const clearUpdatedSeenTimer = useCallback(() => {
     if (updatedSeenTimerRef.current) {
       clearTimeout(updatedSeenTimerRef.current);
@@ -236,6 +253,12 @@ export const ScrollableContainer = ({
     }
   }, []);
 
+  /**
+   * Finds a rendered callout card in the scroll stack by its visualisation name.
+   *
+   * @param {string} name - Card/visualisation identifier.
+   * @returns {HTMLElement|null} Matching card element, if rendered.
+   */
   const getCardElementByName = useCallback((name) => {
     const container = scrollRef.current;
     if (!container || !name) return null;
@@ -247,6 +270,11 @@ export const ScrollableContainer = ({
     );
   }, []);
 
+  /**
+   * Resolves the first updated card and its DOM element when available.
+   *
+   * @returns {{name: string|null, element: HTMLElement|null}} Updated card lookup result.
+   */
   const getFirstUpdatedCardElement = useCallback(() => {
     for (const name of updatedNames) {
       const element = getCardElementByName(name);
@@ -259,6 +287,12 @@ export const ScrollableContainer = ({
     };
   }, [updatedNames, getCardElementByName]);
 
+  /**
+   * Checks whether any part of an element intersects the visible stack viewport.
+   *
+   * @param {HTMLElement|null} element - Card element to inspect.
+   * @returns {boolean} True when the element is at least partly visible.
+   */
   const isElementInScrollView = useCallback((element) => {
     const container = scrollRef.current;
     if (!container || !element) return false;
@@ -275,6 +309,8 @@ export const ScrollableContainer = ({
   /**
    * Only report overflow when another callout card is completely outside the
    * visible area. A merely clipped/partially visible card no longer counts.
+   *
+   * @returns {{canScroll: boolean, canScrollUp: boolean, canScrollDown: boolean}} Overflow state.
    */
   const getCardOverflowState = useCallback(() => {
     const container = scrollRef.current;
@@ -324,6 +360,8 @@ export const ScrollableContainer = ({
   /**
    * Scrolls within the callout stack only. Avoids browser scrollIntoView()
    * bubbling up and scrolling the page/map layout.
+   *
+   * @param {HTMLElement|null} cardElement - Card to centre in the stack.
    */
   const scrollCardIntoView = useCallback((cardElement) => {
     const container = scrollRef.current;
@@ -346,6 +384,11 @@ export const ScrollableContainer = ({
     });
   }, []);
 
+  /**
+   * Opens a collapsed callout card before scrolling to it.
+   *
+   * @param {HTMLElement|null} cardElement - Card element to open.
+   */
   const openCardIfClosed = useCallback((cardElement) => {
     if (!cardElement) return;
 
@@ -358,6 +401,10 @@ export const ScrollableContainer = ({
     }
   }, []);
 
+  /**
+   * Tracks the first updated card and schedules acknowledgement when it is both
+   * open and visible to the user.
+   */
   const evaluateUpdatedCardVisibility = useCallback(() => {
     clearUpdatedSeenTimer();
 
@@ -391,6 +438,9 @@ export const ScrollableContainer = ({
     updatedNames,
   ]);
 
+  /**
+   * Tracks mobile breakpoint changes and keeps desktop stacks open.
+   */
   useEffect(() => {
     if (
       typeof window === "undefined" ||
@@ -401,6 +451,11 @@ export const ScrollableContainer = ({
 
     const mql = window.matchMedia(MOBILE_Q);
 
+    /**
+     * Applies a media-query change event to local mobile/open state.
+     *
+     * @param {MediaQueryList|MediaQueryListEvent} event - Current media query state.
+     */
     const onChange = (event) => {
       setIsMobile(event.matches);
       if (!event.matches) setOpen(true);
@@ -414,14 +469,24 @@ export const ScrollableContainer = ({
     };
   }, []);
 
+  /**
+   * Reopens the mobile summary automatically when cards become available again.
+   */
   useEffect(() => {
     if (isMobile && showOnMobile) setOpen(true);
   }, [isMobile, showOnMobile]);
 
+  /**
+   * Recomputes overflow and update visibility on scroll, resize, content, and
+   * open-state changes.
+   */
   useEffect(() => {
     const element = scrollRef.current;
     if (!element) return undefined;
 
+    /**
+     * Refreshes overflow direction and updated-card visibility state.
+     */
     const updateOverflowState = () => {
       setOverflowState(getCardOverflowState());
       evaluateUpdatedCardVisibility();
@@ -453,6 +518,10 @@ export const ScrollableContainer = ({
     getCardOverflowState,
   ]);
 
+  /**
+   * Re-evaluates updated-card visibility when the updated-card list changes and
+   * clears pending timers on cleanup.
+   */
   useEffect(() => {
     evaluateUpdatedCardVisibility();
 
@@ -473,6 +542,11 @@ export const ScrollableContainer = ({
     ? "up"
     : null;
 
+  /**
+   * Builds the stack hint label from updated-card state before ordinary overflow.
+   *
+   * @returns {string} Button text for the stack hint.
+   */
   const overflowHintText = (() => {
     if (hasUpdatedCards) {
       return `${updatedNames.length} card${
@@ -490,6 +564,10 @@ export const ScrollableContainer = ({
     (overflowState.canScroll &&
       (overflowState.canScrollDown || overflowState.canScrollUp));
 
+  /**
+   * Handles the stack hint click, prioritising updated-card navigation before
+   * ordinary up/down overflow scrolling.
+   */
   const handleOverflowHintClick = () => {
     const container = scrollRef.current;
     if (!container) return;
@@ -539,6 +617,13 @@ export const ScrollableContainer = ({
     onOverflowHintClick?.();
   };
 
+  /**
+   * Renders children, hiding individual card handles for mobile stack content
+   * when the mobile bar is responsible for disclosure.
+   *
+   * @param {boolean} forMobile - Whether children are being rendered into mobile UI.
+   * @returns {React.ReactNode} Rendered children.
+   */
   const renderChildren = (forMobile) =>
     React.Children.map(children, (child) =>
       hideCardHandleOnMobile && forMobile && React.isValidElement(child)
@@ -546,6 +631,11 @@ export const ScrollableContainer = ({
         : child
     );
 
+  /**
+   * Renders the status dot or directional chevron for the stack hint.
+   *
+   * @returns {JSX.Element} Leading icon.
+   */
   const renderLeadingIcon = () => {
     if (hasUpdatedCards) {
       return <OverflowDot $hasUpdates aria-hidden="true" />;
@@ -558,6 +648,11 @@ export const ScrollableContainer = ({
     return <Chevron $direction={overflowDirection} aria-hidden="true" />;
   };
 
+  /**
+   * Renders the sticky stack hint for updated cards or fully hidden overflow.
+   *
+   * @returns {JSX.Element} Overflow hint control.
+   */
   const renderOverflowHint = () => (
     <OverflowHintWrap $visible={shouldShowOverflowHint}>
       <OverflowHint

--- a/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.jsx
+++ b/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.jsx
@@ -16,6 +16,8 @@ const { PADDING } = CARD_CONSTANTS;
 
 const MOBILE_Q = "(max-width: 900px)";
 const EMPTY_UPDATED_CARD_NAMES = [];
+const EMPTY_UPDATED_CARD_EXPIRIES = {};
+const UPDATE_MARKER_TIMEOUT_MS = 2800;
 
 /**
  * Resolves the mobile media query from theme when supplied, with a local fallback.
@@ -203,6 +205,7 @@ const normaliseUpdatedNames = (updatedCardNames) => {
  * @param {boolean} [props.hideCardHandleOnMobile=true]
  * @param {boolean} [props.showOnMobile=true]
  * @param {string[]|Set<string>} [props.updatedCardNames=[]]
+ * @param {Object<string, number>} [props.updatedCardExpiresAtByName] - Fixed auto-clear expiry times by card name.
  * @param {Function} [props.onUpdatedCardSeen]
  * @param {Function} [props.onUpdatedCardsClicked]
  * @param {Function} [props.onOverflowHintClick]
@@ -215,6 +218,7 @@ export const ScrollableContainer = ({
   hideCardHandleOnMobile = true,
   showOnMobile = true,
   updatedCardNames = EMPTY_UPDATED_CARD_NAMES,
+  updatedCardExpiresAtByName = EMPTY_UPDATED_CARD_EXPIRIES,
   onUpdatedCardSeen,
   onUpdatedCardsClicked,
   onOverflowHintClick,
@@ -422,19 +426,33 @@ export const ScrollableContainer = ({
     const isInView = isElementInScrollView(element);
 
     /**
-     * Keep the marker if the updated card is out of view or collapsed.
-     * If it is open and visible, clear after a short timeout.
+     * Keep the marker if the updated card is out of view or collapsed. If it is
+     * open and visible, clear when the card-level marker reaches the same expiry.
      */
     if (isOpen && isInView) {
+      const autoClearAt = updatedCardExpiresAtByName[name];
+      const timeoutMs =
+        typeof autoClearAt === "number"
+          ? Math.max(0, autoClearAt - Date.now())
+          : UPDATE_MARKER_TIMEOUT_MS;
+
       updatedSeenTimerRef.current = setTimeout(() => {
-        onUpdatedCardSeen?.(name);
-      }, 2800);
+        const currentElement = getCardElementByName(name);
+        const isStillOpen =
+          currentElement?.getAttribute("data-callout-card-open") === "true";
+
+        if (isStillOpen && isElementInScrollView(currentElement)) {
+          onUpdatedCardSeen?.(name);
+        }
+      }, timeoutMs);
     }
   }, [
     clearUpdatedSeenTimer,
+    getCardElementByName,
     getFirstUpdatedCardElement,
     isElementInScrollView,
     onUpdatedCardSeen,
+    updatedCardExpiresAtByName,
     updatedNames,
   ]);
 

--- a/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.jsx
+++ b/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.jsx
@@ -230,6 +230,16 @@ export const ScrollableContainer = ({
 
   const [isMobile, setIsMobile] = useState(initialIsMobile);
   const [open, setOpen] = useState(!initialIsMobile);
+  const [mobilePortalSlot, setMobilePortalSlot] = useState(null);
+
+  useEffect(() => {
+    if (!isMobile) {
+      setMobilePortalSlot(null);
+      return;
+    }
+    if (typeof document === "undefined") return;
+    setMobilePortalSlot(document.getElementById("mobile-cards-slot"));
+  }, [isMobile]);
 
   const scrollRef = useRef(null);
   const updatedSeenTimerRef = useRef(null);
@@ -694,11 +704,7 @@ export const ScrollableContainer = ({
   );
 
   if (isMobile) {
-    const slot =
-      typeof document !== "undefined" &&
-      document.getElementById("mobile-cards-slot");
-
-    if (slot) {
+    if (mobilePortalSlot) {
       return createPortal(
         <>
           {showOnMobile && (
@@ -723,9 +729,10 @@ export const ScrollableContainer = ({
             {renderOverflowHint()}
           </StyledScrollableContainer>
         </>,
-        slot
+        mobilePortalSlot
       );
     }
+    return null;
   }
 
   return (

--- a/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.jsx
+++ b/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.jsx
@@ -1,19 +1,26 @@
-import styled from 'styled-components'
-import React, { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
-import { AccordionIcon } from '../Sidebar/Accordion/AccordionSection';
-import { MobileBar } from '../MobileBar/MobileBar';
+import styled from "styled-components";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { AccordionIcon } from "../Sidebar/Accordion/AccordionSection";
+import { MobileBar } from "../MobileBar/MobileBar";
 
-import { CARD_CONSTANTS } from 'defaults';
-const { PADDING } = CARD_CONSTANTS
+import { CARD_CONSTANTS } from "defaults";
 
-const MOBILE_Q = '(max-width: 900px)';
-const mobileMQ = (p) => (p.theme?.mq?.mobile || MOBILE_Q);
+const { PADDING } = CARD_CONSTANTS;
+
+const MOBILE_Q = "(max-width: 900px)";
+const mobileMQ = (p) => p.theme?.mq?.mobile || MOBILE_Q;
 
 const StyledScrollableContainer = styled.div`
   position: absolute;
   right: 0;
-  display: flex;
+  display: ${({ $hidden }) => ($hidden ? "none" : "flex")};
   flex-direction: column;
   align-items: flex-end;
   padding: ${PADDING}px;
@@ -25,8 +32,7 @@ const StyledScrollableContainer = styled.div`
   overflow-x: hidden;
   width: fit-content;
   transition: transform 0.3s ease-in-out;
-  
-  /* MOBILE: sit under Filters and collapse */
+
   @media ${mobileMQ} {
     position: static;
     right: auto;
@@ -34,108 +40,604 @@ const StyledScrollableContainer = styled.div`
     width: 100%;
     box-sizing: border-box;
 
-    /* simple open/close */
-    max-height: ${({ $open }) => ($open ? '60vh' : '0')};
-    overflow-y: ${({ $open }) => ($open ? 'auto' : 'hidden')};
+    max-height: ${({ $open }) => ($open ? "60vh" : "0")};
+    overflow-y: ${({ $open }) => ($open ? "auto" : "hidden")};
     overflow-x: hidden;
-    padding: ${({ $open }) => ($open ? `${PADDING}px` : '0')};
-    gap: ${({ $open }) => ($open ? `${PADDING}px` : '0')};
+    padding: ${({ $open }) => ($open ? `${PADDING}px` : "0")};
+    gap: ${({ $open }) => ($open ? `${PADDING}px` : "0")};
     box-shadow: none;
     border-radius: 0;
     background: #fff;
 
-    /* make children full width */
-    & > * { width: 100% !important; }
+    & > * {
+      width: 100% !important;
+    }
   }
 `;
 
 /**
- * ScrollableContainer component to wrap visualization cards.
- *
- * @param {Object} props - The component props.
- * @param {React.ReactNode} props.children - The children to render inside the container.
- * @returns {JSX.Element} The rendered ScrollableContainer component.
+ * Sticky wrapper keeps the pill above card content while avoiding a full-width
+ * button visual. Width is only used for positioning; the pill itself remains compact.
  */
-  export const ScrollableContainer = ({
-    children,
-    mobileTitle = 'Summary',
-    mobileBarColor,
-    hideCardHandleOnMobile = true,
-    showOnMobile  = true,
-  }) => {
-    // read current breakpoint
-    const initialIsMobile =
-      typeof window !== 'undefined' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia(MOBILE_Q).matches;
+const OverflowHintWrap = styled.div`
+  position: sticky;
+  bottom: 10px;
 
-    // open on desktop, closed by default on mobile
-    const [isMobile, setIsMobile] = useState(initialIsMobile);
-    const [open, setOpen] = useState(!initialIsMobile);
+  display: ${({ $visible }) => ($visible ? "flex" : "none")};
+  justify-content: center;
+  align-self: stretch;
+  padding-top: 10px;
 
-    useEffect(() => {
-      if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
-      const mql = window.matchMedia(MOBILE_Q);
-      const onChange = (e) => {
-        setIsMobile(e.matches);
-        if (!e.matches) setOpen(true); // always open on desktop
-      };
-      onChange(mql);
-      mql.addEventListener('change', onChange);
-      return () => mql.removeEventListener('change', onChange);
-    }, []);
+  z-index: 4000;
+  pointer-events: none;
 
-    useEffect(() => {
-      if (isMobile && showOnMobile) setOpen(true);
-    }, [isMobile, showOnMobile]);
+  @media ${mobileMQ} {
+    bottom: 8px;
+    margin-top: 8px;
+    padding-top: 10px;
+  }
+`;
 
-      // If there’s nothing to show, render nothing
-    const hasChildren = React.Children.toArray(children).some(Boolean);
-    if (!hasChildren) return null;
+const OverflowHint = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
 
-    const hidden = isMobile && !showOnMobile;
+  width: auto;
+  min-width: 148px;
+  max-width: min(260px, calc(100% - 32px));
 
-    // MOBILE: mount outside the map into a slot under the Filters bar
-    if (isMobile) {
-      const slot = typeof document !== 'undefined' && document.getElementById('mobile-cards-slot');
-      if (slot) return createPortal(
-        <>
-          {showOnMobile && (
-            <MobileBar $bgColor={mobileBarColor} onClick={() => setOpen((v) => !v)} aria-expanded={open}>
-              <span>{mobileTitle}</span>
-              <AccordionIcon className="chev" $isOpen={open} />
-            </MobileBar>
-          )}
+  padding: 7px 14px;
 
-          <StyledScrollableContainer $open={open} $hidden={hidden} data-testid="container" className="selectable-text">
-            {React.Children.map(children, (child) =>
-              hideCardHandleOnMobile && React.isValidElement(child)
-                ? React.cloneElement(child, { hideHandleOnMobile: true })
-                : child
-            )}
-          </StyledScrollableContainer>
-        </>, slot);
+  border: 0;
+  border-radius: 999px;
+  background: rgba(24, 20, 69, 0.96);
+  color: #fff;
+
+  font-family: inherit;
+  font-size: 0.76rem;
+  font-weight: 800;
+  line-height: 1;
+
+  cursor: pointer;
+  pointer-events: auto;
+
+  box-shadow:
+    0 5px 14px rgba(13, 15, 61, 0.28),
+    0 1px 3px rgba(13, 15, 61, 0.2);
+
+  transition:
+    transform 140ms ease,
+    background-color 140ms ease,
+    box-shadow 140ms ease,
+    opacity 140ms ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    background: rgba(36, 29, 91, 0.98);
+    box-shadow:
+      0 8px 18px rgba(13, 15, 61, 0.34),
+      0 2px 5px rgba(13, 15, 61, 0.24);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow:
+      0 4px 10px rgba(13, 15, 61, 0.3),
+      0 1px 3px rgba(13, 15, 61, 0.2);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 3px;
+  }
+`;
+
+const OverflowText = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const OverflowDot = styled.span`
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+
+  background: ${({ $hasUpdates }) => ($hasUpdates ? "#00dec6" : "#fff")};
+  box-shadow: ${({ $hasUpdates }) =>
+    $hasUpdates ? "0 0 0 4px rgba(0, 222, 198, 0.22)" : "none"};
+`;
+
+const Chevron = styled.span`
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+
+  transform: ${({ $direction }) =>
+    $direction === "up" ? "rotate(225deg)" : "rotate(45deg)"};
+
+  margin-top: ${({ $direction }) => ($direction === "up" ? "3px" : "-3px")};
+`;
+
+const normaliseUpdatedNames = (updatedCardNames) => {
+  if (!updatedCardNames) return [];
+  if (updatedCardNames instanceof Set) return [...updatedCardNames];
+  if (Array.isArray(updatedCardNames)) return updatedCardNames;
+  return [];
+};
+
+/**
+ * ScrollableContainer component to wrap visualisation cards.
+ *
+ * Behaviour:
+ * - Owns the only scroll surface for callout cards.
+ * - Shows a compact centred pill when:
+ *   - cards have updated;
+ *   - a card is fully above the visible scroll area;
+ *   - a card is fully below the visible scroll area.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} props.children
+ * @param {string} [props.mobileTitle='Summary']
+ * @param {string} [props.mobileBarColor]
+ * @param {boolean} [props.hideCardHandleOnMobile=true]
+ * @param {boolean} [props.showOnMobile=true]
+ * @param {string[]|Set<string>} [props.updatedCardNames=[]]
+ * @param {Function} [props.onUpdatedCardSeen]
+ * @param {Function} [props.onUpdatedCardsClicked]
+ * @param {Function} [props.onOverflowHintClick]
+ * @returns {JSX.Element|null}
+ */
+export const ScrollableContainer = ({
+  children,
+  mobileTitle = "Summary",
+  mobileBarColor,
+  hideCardHandleOnMobile = true,
+  showOnMobile = true,
+  updatedCardNames = [],
+  onUpdatedCardSeen,
+  onUpdatedCardsClicked,
+  onOverflowHintClick,
+}) => {
+  const initialIsMobile =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia(MOBILE_Q).matches;
+
+  const [isMobile, setIsMobile] = useState(initialIsMobile);
+  const [open, setOpen] = useState(!initialIsMobile);
+
+  const scrollRef = useRef(null);
+  const updatedSeenTimerRef = useRef(null);
+
+  const updatedNames = useMemo(
+    () => normaliseUpdatedNames(updatedCardNames).filter(Boolean),
+    [updatedCardNames]
+  );
+
+  const [overflowState, setOverflowState] = useState({
+    canScroll: false,
+    canScrollUp: false,
+    canScrollDown: false,
+  });
+
+  const [firstUpdatedCardName, setFirstUpdatedCardName] = useState(null);
+
+  const clearUpdatedSeenTimer = useCallback(() => {
+    if (updatedSeenTimerRef.current) {
+      clearTimeout(updatedSeenTimerRef.current);
+      updatedSeenTimerRef.current = null;
+    }
+  }, []);
+
+  const getCardElementByName = useCallback((name) => {
+    const container = scrollRef.current;
+    if (!container || !name) return null;
+
+    const cards = container.querySelectorAll("[data-callout-card-name]");
+
+    return [...cards].find(
+      (card) => card.getAttribute("data-callout-card-name") === name
+    );
+  }, []);
+
+  const getFirstUpdatedCardElement = useCallback(() => {
+    for (const name of updatedNames) {
+      const element = getCardElementByName(name);
+      if (element) return { name, element };
     }
 
-    // DESKTOP: keep the current overlay behavior
+    return {
+      name: updatedNames[0] ?? null,
+      element: null,
+    };
+  }, [updatedNames, getCardElementByName]);
+
+  const isElementInScrollView = useCallback((element) => {
+    const container = scrollRef.current;
+    if (!container || !element) return false;
+
+    const containerRect = container.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+
     return (
-      <div style={{ position: 'relative' }}>
+      elementRect.bottom > containerRect.top &&
+      elementRect.top < containerRect.bottom
+    );
+  }, []);
+
+  /**
+   * Only report overflow when another callout card is completely outside the
+   * visible area. A merely clipped/partially visible card no longer counts.
+   */
+  const getCardOverflowState = useCallback(() => {
+    const container = scrollRef.current;
+
+    if (!container) {
+      return {
+        canScroll: false,
+        canScrollUp: false,
+        canScrollDown: false,
+      };
+    }
+
+    const threshold = 2;
+    const canScroll = container.scrollHeight > container.clientHeight + threshold;
+
+    if (!canScroll) {
+      return {
+        canScroll: false,
+        canScrollUp: false,
+        canScrollDown: false,
+      };
+    }
+
+    const containerRect = container.getBoundingClientRect();
+
+    const cards = Array.from(
+      container.querySelectorAll("[data-callout-card-name]")
+    );
+
+    const hasFullyHiddenCardAbove = cards.some((card) => {
+      const rect = card.getBoundingClientRect();
+      return rect.bottom <= containerRect.top + threshold;
+    });
+
+    const hasFullyHiddenCardBelow = cards.some((card) => {
+      const rect = card.getBoundingClientRect();
+      return rect.top >= containerRect.bottom - threshold;
+    });
+
+    return {
+      canScroll,
+      canScrollUp: hasFullyHiddenCardAbove,
+      canScrollDown: hasFullyHiddenCardBelow,
+    };
+  }, []);
+
+  /**
+   * Scrolls within the callout stack only. Avoids browser scrollIntoView()
+   * bubbling up and scrolling the page/map layout.
+   */
+  const scrollCardIntoView = useCallback((cardElement) => {
+    const container = scrollRef.current;
+    if (!container || !cardElement) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const cardRect = cardElement.getBoundingClientRect();
+
+    const cardTopWithinContainer =
+      cardRect.top - containerRect.top + container.scrollTop;
+
+    const targetTop =
+      cardTopWithinContainer -
+      container.clientHeight / 2 +
+      cardElement.offsetHeight / 2;
+
+    container.scrollTo({
+      top: Math.max(0, targetTop),
+      behavior: "smooth",
+    });
+  }, []);
+
+  const openCardIfClosed = useCallback((cardElement) => {
+    if (!cardElement) return;
+
+    const isOpen = cardElement.getAttribute("data-callout-card-open") === "true";
+    if (isOpen) return;
+
+    const toggleButton = cardElement.querySelector("[data-callout-card-toggle]");
+    if (toggleButton instanceof HTMLElement) {
+      toggleButton.click();
+    }
+  }, []);
+
+  const evaluateUpdatedCardVisibility = useCallback(() => {
+    clearUpdatedSeenTimer();
+
+    if (updatedNames.length === 0) {
+      setFirstUpdatedCardName(null);
+      return;
+    }
+
+    const { name, element } = getFirstUpdatedCardElement();
+    setFirstUpdatedCardName(name);
+
+    if (!name || !element) return;
+
+    const isOpen = element.getAttribute("data-callout-card-open") === "true";
+    const isInView = isElementInScrollView(element);
+
+    /**
+     * Keep the marker if the updated card is out of view or collapsed.
+     * If it is open and visible, clear after a short timeout.
+     */
+    if (isOpen && isInView) {
+      updatedSeenTimerRef.current = setTimeout(() => {
+        onUpdatedCardSeen?.(name);
+      }, 2800);
+    }
+  }, [
+    clearUpdatedSeenTimer,
+    getFirstUpdatedCardElement,
+    isElementInScrollView,
+    onUpdatedCardSeen,
+    updatedNames,
+  ]);
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return undefined;
+    }
+
+    const mql = window.matchMedia(MOBILE_Q);
+
+    const onChange = (event) => {
+      setIsMobile(event.matches);
+      if (!event.matches) setOpen(true);
+    };
+
+    onChange(mql);
+    mql.addEventListener("change", onChange);
+
+    return () => {
+      mql.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isMobile && showOnMobile) setOpen(true);
+  }, [isMobile, showOnMobile]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return undefined;
+
+    const updateOverflowState = () => {
+      setOverflowState(getCardOverflowState());
+      evaluateUpdatedCardVisibility();
+    };
+
+    updateOverflowState();
+
+    element.addEventListener("scroll", updateOverflowState, { passive: true });
+
+    let resizeObserver;
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(updateOverflowState);
+      resizeObserver.observe(element);
+    }
+
+    window.addEventListener("resize", updateOverflowState);
+
+    return () => {
+      element.removeEventListener("scroll", updateOverflowState);
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateOverflowState);
+    };
+  }, [
+    children,
+    open,
+    isMobile,
+    showOnMobile,
+    evaluateUpdatedCardVisibility,
+    getCardOverflowState,
+  ]);
+
+  useEffect(() => {
+    evaluateUpdatedCardVisibility();
+
+    return () => {
+      clearUpdatedSeenTimer();
+    };
+  }, [evaluateUpdatedCardVisibility, clearUpdatedSeenTimer]);
+
+  const hasChildren = React.Children.toArray(children).some(Boolean);
+  if (!hasChildren) return null;
+
+  const hidden = isMobile && !showOnMobile;
+  const hasUpdatedCards = updatedNames.length > 0;
+
+  const overflowDirection = overflowState.canScrollDown
+    ? "down"
+    : overflowState.canScrollUp
+    ? "up"
+    : null;
+
+  const overflowHintText = (() => {
+    if (hasUpdatedCards) {
+      return `${updatedNames.length} card${
+        updatedNames.length === 1 ? "" : "s"
+      } updated`;
+    }
+
+    if (overflowState.canScrollDown) return "More cards below";
+    if (overflowState.canScrollUp) return "More cards above";
+    return "";
+  })();
+
+  const shouldShowOverflowHint =
+    hasUpdatedCards ||
+    (overflowState.canScroll &&
+      (overflowState.canScrollDown || overflowState.canScrollUp));
+
+  const handleOverflowHintClick = () => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    if (hasUpdatedCards) {
+      const { name, element: cardElement } = getFirstUpdatedCardElement();
+
+      if (cardElement) {
+        openCardIfClosed(cardElement);
+
+        /*
+        * Wait a tick so the card can begin opening before we centre it.
+        * This avoids scrolling to the collapsed shell and then expanding off-position.
+        */
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            scrollCardIntoView(cardElement);
+          });
+        });
+      }
+
+      /*
+      * Requirement:
+      * As soon as "card(s) updated" is clicked, reset the stack-level marker.
+      */
+      if (typeof onUpdatedCardsClicked === "function") {
+        onUpdatedCardsClicked(name);
+      } else if (name) {
+        onUpdatedCardSeen?.(name);
+      }
+
+      return;
+    }
+
+    if (overflowState.canScrollDown) {
+      container.scrollBy({
+        top: Math.round(container.clientHeight * 0.8),
+        behavior: "smooth",
+      });
+    } else if (overflowState.canScrollUp) {
+      container.scrollBy({
+        top: -Math.round(container.clientHeight * 0.8),
+        behavior: "smooth",
+      });
+    }
+
+    onOverflowHintClick?.();
+  };
+
+  const renderChildren = (forMobile) =>
+    React.Children.map(children, (child) =>
+      hideCardHandleOnMobile && forMobile && React.isValidElement(child)
+        ? React.cloneElement(child, { hideHandleOnMobile: true })
+        : child
+    );
+
+  const renderLeadingIcon = () => {
+    if (hasUpdatedCards) {
+      return <OverflowDot $hasUpdates aria-hidden="true" />;
+    }
+
+    if (!overflowDirection) {
+      return <OverflowDot aria-hidden="true" />;
+    }
+
+    return <Chevron $direction={overflowDirection} aria-hidden="true" />;
+  };
+
+  const renderOverflowHint = () => (
+    <OverflowHintWrap $visible={shouldShowOverflowHint}>
+      <OverflowHint
+        type="button"
+        onClick={handleOverflowHintClick}
+        aria-label={
+          hasUpdatedCards && firstUpdatedCardName
+            ? `${overflowHintText}. Scroll to ${firstUpdatedCardName}`
+            : overflowHintText || "Callout card status"
+        }
+        title={
+          hasUpdatedCards && firstUpdatedCardName
+            ? `Scroll to ${firstUpdatedCardName}`
+            : overflowHintText || undefined
+        }
+      >
+        {renderLeadingIcon()}
+        <OverflowText>{overflowHintText}</OverflowText>
+      </OverflowHint>
+    </OverflowHintWrap>
+  );
+
+  if (isMobile) {
+    const slot =
+      typeof document !== "undefined" &&
+      document.getElementById("mobile-cards-slot");
+
+    if (slot) {
+      return createPortal(
         <>
-          {isMobile && showOnMobile && (
-            <MobileBar $bgColor={mobileBarColor} onClick={() => setOpen((v) => !v)} aria-expanded={open}>
+          {showOnMobile && (
+            <MobileBar
+              $bgColor={mobileBarColor}
+              onClick={() => setOpen((value) => !value)}
+              aria-expanded={open}
+            >
               <span>{mobileTitle}</span>
               <AccordionIcon className="chev" $isOpen={open} />
             </MobileBar>
           )}
 
-          <StyledScrollableContainer $open={isMobile ? open : true} $hidden={hidden} data-testid="container" className="selectable-text">
-            {React.Children.map(children, child =>
-              hideCardHandleOnMobile && isMobile && React.isValidElement(child)
-                ? React.cloneElement(child, { hideHandleOnMobile: true })
-                : child
-            )}
+          <StyledScrollableContainer
+            ref={scrollRef}
+            $open={open}
+            $hidden={hidden}
+            data-testid="container"
+            className="selectable-text"
+          >
+            {renderChildren(true)}
+            {renderOverflowHint()}
           </StyledScrollableContainer>
-        </>
-      </div>
-    );
-  };
+        </>,
+        slot
+      );
+    }
+  }
+
+  return (
+    <div style={{ position: "relative" }}>
+      {isMobile && showOnMobile && (
+        <MobileBar
+          $bgColor={mobileBarColor}
+          onClick={() => setOpen((value) => !value)}
+          aria-expanded={open}
+        >
+          <span>{mobileTitle}</span>
+          <AccordionIcon className="chev" $isOpen={open} />
+        </MobileBar>
+      )}
+
+      <StyledScrollableContainer
+        ref={scrollRef}
+        $open={isMobile ? open : true}
+        $hidden={hidden}
+        data-testid="container"
+        className="selectable-text"
+      >
+        {renderChildren(isMobile)}
+        {renderOverflowHint()}
+      </StyledScrollableContainer>
+    </div>
+  );
+};

--- a/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.test.jsx
+++ b/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.test.jsx
@@ -1,5 +1,6 @@
 import { ScrollableContainer } from "Components/ScrollableContainer";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { CARD_CONSTANTS } from 'defaults';
 const { PADDING } = CARD_CONSTANTS
 
@@ -10,5 +11,73 @@ describe("ScrollableContainer component test", () => {
         expect(element).toBeInTheDocument();
         const container = screen.getByTestId("container");
         expect(container).toHaveStyle(`padding: ${PADDING}px;`);
+    });
+
+    it("shows an updated-card hint and clears it when clicked", async () => {
+        const user = userEvent.setup();
+        const onUpdatedCardsClicked = jest.fn();
+        const toggle = jest.fn();
+        const originalRequestAnimationFrame = global.requestAnimationFrame;
+        const originalScrollTo = HTMLElement.prototype.scrollTo;
+
+        global.requestAnimationFrame = (callback) => {
+            callback();
+            return 1;
+        };
+        HTMLElement.prototype.scrollTo = jest.fn();
+
+        render(
+            <ScrollableContainer
+                updatedCardNames={new Set(["card-a"])}
+                onUpdatedCardsClicked={onUpdatedCardsClicked}
+            >
+                <div data-callout-card-name="card-a" data-callout-card-open="false">
+                    <button data-callout-card-toggle onClick={toggle}>Toggle card</button>
+                    Card A
+                </div>
+            </ScrollableContainer>
+        );
+
+        await user.click(screen.getByRole("button", { name: /1 card updated/i }));
+
+        expect(toggle).toHaveBeenCalledTimes(1);
+        expect(onUpdatedCardsClicked).toHaveBeenCalledWith("card-a");
+
+        global.requestAnimationFrame = originalRequestAnimationFrame;
+        HTMLElement.prototype.scrollTo = originalScrollTo;
+    });
+
+    it("marks an open visible updated card as seen after the timeout", () => {
+        jest.useFakeTimers();
+        const onUpdatedCardSeen = jest.fn();
+        const rectSpy = jest.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+            top: 0,
+            bottom: 20,
+            left: 0,
+            right: 20,
+            width: 20,
+            height: 20,
+            x: 0,
+            y: 0,
+            toJSON: () => {},
+        });
+
+        render(
+            <ScrollableContainer
+                updatedCardNames={["card-a"]}
+                onUpdatedCardSeen={onUpdatedCardSeen}
+            >
+                <div data-callout-card-name="card-a" data-callout-card-open="true">Card A</div>
+            </ScrollableContainer>
+        );
+
+        act(() => {
+            jest.advanceTimersByTime(2800);
+        });
+
+        expect(onUpdatedCardSeen).toHaveBeenCalledWith("card-a");
+
+        rectSpy.mockRestore();
+        jest.useRealTimers();
     });
 });

--- a/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.test.jsx
+++ b/packages/vis-core/src/Components/ScrollableContainer/ScrollableContainer.test.jsx
@@ -49,6 +49,7 @@ describe("ScrollableContainer component test", () => {
 
     it("marks an open visible updated card as seen after the timeout", () => {
         jest.useFakeTimers();
+        jest.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
         const onUpdatedCardSeen = jest.fn();
         const rectSpy = jest.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
             top: 0,
@@ -76,6 +77,108 @@ describe("ScrollableContainer component test", () => {
         });
 
         expect(onUpdatedCardSeen).toHaveBeenCalledWith("card-a");
+
+        rectSpy.mockRestore();
+        jest.useRealTimers();
+    });
+
+    it("does not restart an unchanged card's seen timer when rerendered", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+        const onUpdatedCardSeen = jest.fn();
+        const rectSpy = jest.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+            top: 0,
+            bottom: 20,
+            left: 0,
+            right: 20,
+            width: 20,
+            height: 20,
+            x: 0,
+            y: 0,
+            toJSON: () => {},
+        });
+        const expiresAt = Date.now() + 2800;
+
+        const { rerender } = render(
+            <ScrollableContainer
+                updatedCardNames={["card-a"]}
+                updatedCardExpiresAtByName={{ "card-a": expiresAt }}
+                onUpdatedCardSeen={onUpdatedCardSeen}
+            >
+                <div data-callout-card-name="card-a" data-callout-card-open="true">Card A</div>
+            </ScrollableContainer>
+        );
+
+        act(() => {
+            jest.advanceTimersByTime(1000);
+        });
+
+        rerender(
+            <ScrollableContainer
+                updatedCardNames={["card-a"]}
+                updatedCardExpiresAtByName={{ "card-a": expiresAt }}
+                onUpdatedCardSeen={onUpdatedCardSeen}
+            >
+                <div data-callout-card-name="card-a" data-callout-card-open="true">Card A</div>
+            </ScrollableContainer>
+        );
+
+        act(() => {
+            jest.advanceTimersByTime(1799);
+        });
+        expect(onUpdatedCardSeen).not.toHaveBeenCalled();
+
+        act(() => {
+            jest.advanceTimersByTime(1);
+        });
+        expect(onUpdatedCardSeen).toHaveBeenCalledWith("card-a");
+
+        rectSpy.mockRestore();
+        jest.useRealTimers();
+    });
+
+    it("does not clear the pill if the card closes before its shared expiry", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+        const onUpdatedCardSeen = jest.fn();
+        const rectSpy = jest.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+            top: 0,
+            bottom: 20,
+            left: 0,
+            right: 20,
+            width: 20,
+            height: 20,
+            x: 0,
+            y: 0,
+            toJSON: () => {},
+        });
+        const expiresAt = Date.now() + 2800;
+
+        const { rerender } = render(
+            <ScrollableContainer
+                updatedCardNames={["card-a"]}
+                updatedCardExpiresAtByName={{ "card-a": expiresAt }}
+                onUpdatedCardSeen={onUpdatedCardSeen}
+            >
+                <div data-callout-card-name="card-a" data-callout-card-open="true">Card A</div>
+            </ScrollableContainer>
+        );
+
+        rerender(
+            <ScrollableContainer
+                updatedCardNames={["card-a"]}
+                updatedCardExpiresAtByName={{ "card-a": expiresAt }}
+                onUpdatedCardSeen={onUpdatedCardSeen}
+            >
+                <div data-callout-card-name="card-a" data-callout-card-open="false">Card A</div>
+            </ScrollableContainer>
+        );
+
+        act(() => {
+            jest.advanceTimersByTime(2800);
+        });
+
+        expect(onUpdatedCardSeen).not.toHaveBeenCalled();
 
         rectSpy.mockRestore();
         jest.useRealTimers();

--- a/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
+++ b/packages/vis-core/src/hooks/useFetchVisualisationData.jsx
@@ -236,6 +236,17 @@ export const useFetchVisualisationData = (
   const abortControllerRef = useRef(null);
   const cacheTimeoutRef = useRef(null);
 
+  const mapRef = useRef(map);
+  const mapLayerIdRef = useRef(mapLayerId);
+  const shouldFilterRef = useRef(shouldFilterDataToViewport);
+
+  // Keep refs aligned
+  useEffect(() => {
+    mapRef.current = map;
+    mapLayerIdRef.current = mapLayerId;
+    shouldFilterRef.current = shouldFilterDataToViewport;
+  }, [map, mapLayerId, shouldFilterDataToViewport]);
+
   /**
    * Resets the fetch state - useful when visualisation changes (e.g., page navigation).
    */
@@ -288,14 +299,17 @@ export const useFetchVisualisationData = (
       debounce(async (vis) => {
         if (!vis) return;
 
+        // Use the current values from refs
+        const currentMap = mapRef.current;
+        const currentMapLayerId = mapLayerIdRef.current;
+        const currentShouldFilter = shouldFilterRef.current;
+
         /**
          * Commit the params signature only when the fetch actually starts.
          * This prevents "scheduled then cancelled" from blocking future fetches.
          */
-        if (pendingParamsSignatureRef.current) {
-          prevParamsRef.current = pendingParamsSignatureRef.current;
-          pendingParamsSignatureRef.current = null;
-        }
+        const paramsSignatureForThisRequest = pendingParamsSignatureRef.current;
+        pendingParamsSignatureRef.current = null;
 
         const {
           dataPath: path,
@@ -314,10 +328,10 @@ export const useFetchVisualisationData = (
         let isBackgroundFetch = false;
 
         // If configured to filter server-side by viewport, add the current bbox to the query params
-        if (shouldFilterDataToViewport && map && typeof map.getBounds === 'function') {
+        if (currentShouldFilter && currentMap && typeof currentMap.getBounds === 'function') {
           try {
-            const bounds = map.getBounds();
-            currentZoom = Math.round(map.getZoom());
+            const bounds = currentMap.getBounds();
+            currentZoom = Math.round(currentMap.getZoom());
             
             const currentExactBbox = {
               west: bounds.getWest(),
@@ -396,8 +410,7 @@ export const useFetchVisualisationData = (
           // swap data in. This avoids a visible tile-swap flash on cache hits without
           // affecting the shared loading state.
           cacheTimeoutRef.current = setTimeout(() => {
-            // If we hit the cache, we still need to merge it into our accumulated data
-            if (shouldFilterDataToViewport && Array.isArray(cachedData)) {
+            if (currentShouldFilter && Array.isArray(cachedData)) {
               lastFetchedBboxRef.current = fetchBbox;
               lastFetchedZoomRef.current = currentZoom;
               
@@ -409,10 +422,16 @@ export const useFetchVisualisationData = (
               
               const mergedData = Array.from(accumulatedDataRef.current.values());
               setRawData(mergedData);
-              if (!map || !mapLayerId) setFilteredData(mergedData);
+              if (!currentMap || !currentMapLayerId) setFilteredData(mergedData);
             } else {
               setRawData(cachedData);
-              if (!map || !mapLayerId || !shouldFilterDataToViewport) setFilteredData(cachedData);
+              if (!currentMap || !currentMapLayerId || !currentShouldFilter) {
+                setFilteredData(cachedData);
+              }
+            }
+
+            if (paramsSignatureForThisRequest) {
+              prevParamsRef.current = paramsSignatureForThisRequest;
             }
             
             // Ensure loading is cleared in case a previous real fetch left it true.
@@ -461,28 +480,25 @@ export const useFetchVisualisationData = (
           // --- DATA ACCUMULATION LOGIC ---
           let finalDataToSet = responseData;
 
-          if (shouldFilterDataToViewport && Array.isArray(responseData)) {
+          if (currentShouldFilter && Array.isArray(responseData)) {
             // Save our successful fetch parameters
             lastFetchedBboxRef.current = fetchBbox;
             lastFetchedZoomRef.current = currentZoom;
-
-            // Merge new data into our accumulated map using the record ID
+            
+            // For viewport-filtered layers, merge the new results into our accumulated cache
             responseData.forEach(item => {
               if (item.id !== undefined && item.id !== null) {
                 accumulatedDataRef.current.set(item.id, item);
               }
             });
-
-            // If items have IDs, use the accumulated data. Otherwise fallback to raw response.
-            if (accumulatedDataRef.current.size > 0) {
-              finalDataToSet = Array.from(accumulatedDataRef.current.values());
-            }
+            
+            finalDataToSet = Array.from(accumulatedDataRef.current.values());
           }
 
           setRawData(finalDataToSet);
 
           // If no viewport filtering is requested or not possible, mirror to filteredData.
-          if (!map || !mapLayerId || !shouldFilterDataToViewport) {
+          if (!currentMap || !currentMapLayerId || !currentShouldFilter) {
             setFilteredData(finalDataToSet);
           }
 
@@ -496,6 +512,11 @@ export const useFetchVisualisationData = (
             setError(e);
           }
         } finally {
+          // Ensure we update prevParamsRef so we don't infinitely retry failing requests
+          if (paramsSignatureForThisRequest && !currentSignal.aborted) {
+            prevParamsRef.current = paramsSignatureForThisRequest;
+          }
+
           // Only turn off loading if THIS specific request wasn't aborted.
           // If it was aborted, a new request has likely already set loading to true.
           if (!currentSignal.aborted) {
@@ -503,7 +524,7 @@ export const useFetchVisualisationData = (
           }
         }
       }, debounceMs),
-    [map, mapLayerId, shouldFilterDataToViewport, debounceMs]
+    [debounceMs]
   );
 
   // Cancel any pending debounced call on unmount to avoid setting state after unmount.
@@ -534,7 +555,8 @@ export const useFetchVisualisationData = (
     }
 
     // Track a combined signature of both param maps to detect changes.
-    const currentParamsStr = JSON.stringify({ queryParams, pathParams });
+    const isMapReady = shouldFilterDataToViewport ? !!map : true;
+    const currentParamsStr = JSON.stringify({ queryParams, pathParams, isMapReady });
 
     const paramsChanged = prevParamsRef.current !== currentParamsStr;
 

--- a/packages/vis-core/src/services/api/Base.js
+++ b/packages/vis-core/src/services/api/Base.js
@@ -210,9 +210,10 @@ class BaseService {
       },
       ...addOptions,
     };
-    const result = await fetch(url, options).catch((error) =>
-      console.log(error)
-    );
+    const result = await fetch(url, options).catch((error) => {
+      console.log(error);
+      throw error;
+    });
     if (!result.ok) {
       throw new Error(`HTTP error! status: ${result.status}`);
     }
@@ -249,7 +250,11 @@ class BaseService {
       arrayFormat: options?.queryOptions?.arrayFormat,
     });
     const path = params ? `${withPathParams}?${params}` : withPathParams;
-    return await this._get(path, {}, options.skipAuth);
+    return await this._get(
+      path,
+      options.signal ? { signal: options.signal } : {},
+      options.skipAuth
+    );
   }
 
   /**
@@ -274,9 +279,10 @@ class BaseService {
       body: JSON.stringify(data),
       ...addOptions,
     };
-    const result = await fetch(url, options).catch((error) =>
-      console.log(error)
-    );
+    const result = await fetch(url, options).catch((error) => {
+      console.log(error);
+      throw error;
+    });
     if (!result.ok) {
       throw new Error(`HTTP error! status: ${result.status}`);
     }


### PR DESCRIPTION
## Summary

This PR updates callout card rendering so cards no longer jump/reorder every time their data refreshes. Cards now move to the top only once, when they first become visible with real data, and later data changes are surfaced through explicit update indicators instead.

## Changes

- Split callout card lifecycle events into separate callbacks:
  - first visible render
  - visibility changes
  - data updated
  - update acknowledged
- Preserve the previously rendered callout data while a hydrated card is refreshing, so refreshes show an updating state instead of falling back to the loading shell.
- Add per-card update badges and collapsed-card update pings when card data changes.
- Add stack-level update tracking in `VisualisationManager`, including shared expiry handling so unrelated updates do not restart existing timers.
- Add a sticky `ScrollableContainer` hint for updated cards and fully hidden overflow cards.
- Allow the update hint to open/scroll to an updated card without causing the page/map layout itself to scroll.
- Keep mobile summary visibility based on whether any callout cards have renderable data.
- Add stable callout card data attributes used by the scroll/update coordination logic.
- Reserve header space for update/loading badges to avoid layout shift when status text appears or disappears.
- Add and update tests covering:
  - first-visible-only card ordering
  - update marker creation and acknowledgement
  - shared update expiry timing
  - mobile summary visibility
  - scroll container update hints
  - update marker behaviour for open, closed, and visible cards

| | |
| --- | --- |
| Updating | <img width="329" height="106" alt="image" src="https://github.com/user-attachments/assets/cc1093a2-7c0b-4ab2-9a2d-a0c1fb483197" /> |
| Newly updated | <img width="318" height="136" alt="image" src="https://github.com/user-attachments/assets/c1a06b43-2089-40c8-8434-6ad725a4577a" /> |
| Card(s) below | <img width="340" height="68" alt="image" src="https://github.com/user-attachments/assets/c91ace56-26e7-4c91-af89-0f0437a7a7a3" /> |
| Card(s) above | <img width="327" height="77" alt="image" src="https://github.com/user-attachments/assets/3d571c3c-925b-4cec-a081-c33adee7b0f8" /> |
| Card updated out of view | <img width="322" height="87" alt="image" src="https://github.com/user-attachments/assets/36d14b5f-8c90-4c9e-981e-f0c95b8b2568" /> |




## Why

Previously, callout card data refreshes reused the same callback path as initial visibility. That meant every refresh could reorder the callout stack, causing cards to jump around while users were reading or interacting with them.

This change keeps the card stack stable after first render and uses update indicators to show that data has changed.

## Testing

Tests added/updated for:

- `CalloutCardVisualisation`
- `VisualisationManager`
- `ScrollableContainer`