### PR TITLE
Prevent multiselect dropdown callback churn

### DIFF
--- a/packages/vis-core/src/Components/MapLayout/Map.jsx
+++ b/packages/vis-core/src/Components/MapLayout/Map.jsx
@@ -1413,13 +1413,13 @@ const Map = (props) => {
   return (
     <StyledMapContainer ref={mapContainerRef}>
       {Object.values(state.layers).map((layer) => (
-      <>
+      <React.Fragment key={layer.name}>
         <Layer key={layer.name} layer={layer} />
         { /* Create a sibling 'spider' layer for all point layers, to deal with overlaps */}
         {layer.type === 'tile' && layer.geometryType === 'point' && Boolean(layer.spiderfyOverlappingPoints) && (
           <SpiderLayer key={`${layer.name}_spider`} baseLayerId={layer.name} />
         )}
-      </>
+      </React.Fragment>
       ))}
       {state.visualisations && <VisualisationManager
         visualisationConfigs={state.visualisations}

--- a/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
@@ -108,6 +108,33 @@ export const MapLayout = () => {
     });
   }, [filterDispatch]);
 
+  const getSelectedFilterOptions = useCallback((filter, value) => {
+    const values = filter.values?.values;
+    if (!Array.isArray(values)) return [];
+
+    if (Array.isArray(value)) {
+      const selected = new Set(value);
+      return values.filter((item) => selected.has(item.paramValue));
+    }
+
+    const selected = values.find((item) => item.paramValue === value);
+    return selected ? [selected] : [];
+  }, []);
+
+  const buildFilterActionPayload = useCallback((filter, action, value, sides) => {
+    const selectedOptions = getSelectedFilterOptions(filter, value);
+    const payload = { filter, value, ...action.payload };
+
+    if (sides) payload.sides = sides;
+
+    if (action.action === "UPDATE_COLOR_SCHEME") {
+      const colourValue = selectedOptions.find((option) => option.colourValue)?.colourValue;
+      if (colourValue) payload.color_scheme = colourValue;
+    }
+
+    return payload;
+  }, [getSelectedFilterOptions]);
+
   /**
    * Effect A (immediate): keep derived filters in sync with their source selection and metadata.
    * Fires on every filterState change so the UI responds without waiting for the debounce.
@@ -226,44 +253,30 @@ export const MapLayout = () => {
     }
 
     state.filters.forEach((filter) => {
-      let selectedValue
-      if (filter.values?.values && Array.isArray(filter.values.values)) {
-        selectedValue = filter.values?.values.find(
-          (value) => value.paramValue === debouncedFilterState[filter.id]
-        );
-      }
+      const filterValue = debouncedFilterState[filter.id];
+
       if (!filter.visualisations[0].includes("Side")) {
         filter.actions.forEach((action) => {
-          // Add the colour scheme to the payload
-          let additionalPayload
-          if (action.action === "UPDATE_COLOR_SCHEME") {
-            additionalPayload = { ...additionalPayload, color_scheme: selectedValue.colourValue }
-          }
           dispatch({
             type: action.action,
-            payload: { filter, value: debouncedFilterState[filter.id], ...action.payload, ...additionalPayload },
+            payload: buildFilterActionPayload(filter, action, filterValue),
           });
         });
       } else {
         filter.actions.forEach((action) => {
           let sides = "";
 
-          // Add the colour scheme to the payload
-          let additionalPayload
-          if (action.action === "UPDATE_COLOR_SCHEME") {
-            additionalPayload = { ...additionalPayload, color_scheme: selectedValue.colourValue }
-          }
           if (filter.filterName.includes("Left")) sides = "left";
           else if (filter.filterName.includes("Right")) sides = "right";
           else sides = "both";
           dispatch({
             type: action.action,
-            payload: { filter, value: debouncedFilterState[filter.id], sides, ...action.payload, ...additionalPayload },
+            payload: buildFilterActionPayload(filter, action, filterValue, sides),
           });
         });
       }
     });
-  }, [debouncedFilterState, state.metadataTables, state.filters, dispatch]);
+  }, [debouncedFilterState, state.metadataTables, state.filters, dispatch, buildFilterActionPayload]);
 
   const handleColorChange = (color, layerName) => {
     dispatch({

--- a/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { Dimmer, MapLayerSection, Sidebar, DynamicStylingStatus } from "Components";
 import { PageContext } from "contexts";
@@ -101,12 +101,12 @@ export const MapLayout = () => {
     }
   }, [pageContext, filterDispatch]);
 
-  const handleFilterChange = (filter, value) => {
+  const handleFilterChange = useCallback((filter, value) => {
     filterDispatch({
       type: 'SET_FILTER_VALUE',
       payload: { filterId: filter.id, value, filter },
     });
-  };
+  }, [filterDispatch]);
 
   /**
    * Effect A (immediate): keep derived filters in sync with their source selection and metadata.

--- a/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
@@ -108,6 +108,13 @@ export const MapLayout = () => {
     });
   }, [filterDispatch]);
 
+  /**
+   * Retrieves the full option objects corresponding to a filter's selected value(s).
+   *
+   * @param {Object} filter - The filter configuration object, containing a `values` property with an array of options.
+   * @param {any|any[]} value - The currently selected value (scalar for single-select) or array of values (for multi-select).
+   * @returns {Object[]} An array of matching option objects from the filter's configuration. Returns an empty array if no matches are found or if the filter lacks options.
+   */
   const getSelectedFilterOptions = useCallback((filter, value) => {
     const values = filter.values?.values;
     if (!Array.isArray(values)) return [];
@@ -121,6 +128,15 @@ export const MapLayout = () => {
     return selected ? [selected] : [];
   }, []);
 
+  /**
+   * Constructs the payload for dispatching map reducer actions triggered by filter changes.
+   *
+   * @param {Object} filter - The filter configuration object triggering the action.
+   * @param {Object} action - The action definition, including its base `payload` and action type (e.g., `UPDATE_COLOR_SCHEME`).
+   * @param {any|any[]} value - The currently selected value(s) for the filter.
+   * @param {string[]} [sides] - Optional list of panel sides the action applies to, used in dual-map layouts.
+   * @returns {Object} The enriched payload containing the filter, selected value(s), original action payload parameters, and potentially resolved colour schemes.
+   */
   const buildFilterActionPayload = useCallback((filter, action, value, sides) => {
     const selectedOptions = getSelectedFilterOptions(filter, value);
     const payload = { filter, value, ...action.payload };

--- a/packages/vis-core/src/Components/MapLayout/MapLayout.test.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapLayout.test.jsx
@@ -388,4 +388,61 @@ describe("tests when !filter.visualisations[0].includes(`Side`)", () => {
       },
     });
   });
+
+  it("dispatches multiselect values without treating them as scalar options", () => {
+    const multiFilterContext = {
+      ...mockFilterContext,
+      state: {
+        ...mockFilterContext.state,
+        multi: ["bus", "rail"],
+      },
+      dispatch: jest.fn(),
+    };
+
+    const multiMapContext = {
+      ...mockMapContext,
+      dispatch: jest.fn(),
+      state: {
+        ...mockMapContext.state,
+        filters: [
+          {
+            actions: [{ action: "UPDATE_COLOR_SCHEME" }],
+            filterName: "Mode",
+            visualisations: ["Other"],
+            multiSelect: true,
+            values: {
+              values: [
+                { paramValue: "bus", colourValue: "red" },
+                { paramValue: "rail", colourValue: "blue" },
+              ],
+            },
+            id: "multi",
+          },
+        ],
+      },
+    };
+
+    render(
+      <ThemeProvider theme={theme}>
+        <AppContext.Provider value={mockAppContexte}>
+          <PageContext.Provider value={mockPageContext}>
+            <FilterContext.Provider value={multiFilterContext}>
+              <MapContext.Provider value={multiMapContext}>
+                <MapLayout />
+              </MapContext.Provider>
+            </FilterContext.Provider>
+          </PageContext.Provider>
+        </AppContext.Provider>
+      </ThemeProvider>
+    );
+
+    expect(multiMapContext.dispatch).toHaveBeenCalledWith({
+      type: "UPDATE_COLOR_SCHEME",
+      payload: {
+        filter: multiMapContext.state.filters[0],
+        value: ["bus", "rail"],
+        color_scheme: "red",
+      },
+    });
+  });
 });

--- a/packages/vis-core/src/Components/Sidebar/Selectors/Dropdown.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Selectors/Dropdown.jsx
@@ -249,20 +249,33 @@ export const Dropdown = ({ filter, onChange }) => {
     }
   }, [selectedOptions, filterState, filter, onChange, options]);
 
+  const selectedValue = filterState[filter.id];
+
   // Ensure multi-select selections stay in sync with filtered options, and fallback when emptied.
   useEffect(() => {
     if (!filter.multiSelect) return;
+    if (!Array.isArray(selectedValue)) return;
 
     const current = filterState[filter.id];
     if (!Array.isArray(current)) return;
 
-    console.log(`[Dropdown ${filter.filterName}] Current selection:`, current, 'persistState:', filter.persistState);
+    console.log(
+      `[Dropdown ${filter.filterName}] Current selection:`,
+      current,
+      "persistState:",
+      filter.persistState,
+    );
 
     const visibleOptions = options.slice(1); // exclude 'All'
     const visibleValuesSet = new Set(visibleOptions.map((o) => o.value));
     const next = current.filter((v) => visibleValuesSet.has(v));
 
-    console.log(`[Dropdown ${filter.filterName}] After filtering to visible:`, next, 'visible count:', visibleOptions.length);
+    console.log(
+      `[Dropdown ${filter.filterName}] After filtering to visible:`,
+      next,
+      "visible count:",
+      visibleOptions.length,
+    );
 
     // If some selected values were filtered out, prune them.
     if (next.length !== current.length && next.length > 0) {
@@ -274,24 +287,41 @@ export const Dropdown = ({ filter, onChange }) => {
     // Only fallback to "all visible" if forceRequired is true or not explicitly set to false
     // This allows filters with forceRequired: false to have empty selections
     const shouldFallbackToAll = filter.forceRequired !== false;
-    
+
     // Don't override persisted state with "select all" behavior
     // If the filter has persistState enabled and the current selection is intentionally limited,
     // we should respect that rather than auto-selecting all
     const hasPersistState = filter.persistState === true;
-    
+
     // If all selected values are now filtered out, fallback to "all visible" to keep selection valid
     // but only if the filter is required and doesn't have persisted state that should be respected
-    if (current.length > 0 && next.length === 0 && shouldFallbackToAll && !hasPersistState) {
-      console.log(`[Dropdown ${filter.filterName}] All selections invalid, falling back to all`);
+    if (
+      current.length > 0 &&
+      next.length === 0 &&
+      shouldFallbackToAll &&
+      !hasPersistState
+    ) {
+      console.log(
+        `[Dropdown ${filter.filterName}] All selections invalid, falling back to all`,
+      );
       const allVisible = visibleOptions.map((o) => o.value);
       // Mark that 'All' semantic is active so existing logic keeps it updated when options change.
       setIsAllSelected(true);
       onChange(filter, allVisible);
     } else if (current.length > 0 && next.length === 0 && hasPersistState) {
-      console.log(`[Dropdown ${filter.filterName}] All selections invalid but has persistState, not auto-selecting all`);
+      console.log(
+        `[Dropdown ${filter.filterName}] All selections invalid but has persistState, not auto-selecting all`,
+      );
     }
-  }, [optionsSignature, options, filterState, filter, onChange]);
+  }, [
+    selectedValue,
+    optionsSignature,
+    filter.id,
+    filter.multiSelect,
+    filter.persistState,
+    filter.forceRequired,
+    onChange,
+  ]);
 
   /**
    * Sets loading only when the visible options or their validity change,

--- a/packages/vis-core/src/Components/Sidebar/Selectors/SelectorSection.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Selectors/SelectorSection.jsx
@@ -7,7 +7,7 @@ import { SelectorLabel } from "./SelectorLabel";
 import { Slider } from "./Slider";
 import { Toggle } from "./Toggle";
 import { AppContext } from "contexts";
-import { useState, useContext, useEffect } from "react";
+import { useState, useContext, useEffect, useCallback } from "react";
 import { MapFeatureSelect, MapFeatureSelectWithControls } from "./MapFeatureSelect";
 import { CheckboxSelector, MapFeatureSelectAndPan } from ".";
 import { api } from "services";
@@ -73,7 +73,7 @@ const NoDataParagraph = styled.p``;
 export const SelectorSection = ({ filters, onFilterChange, bgColor, downloadPath, downloadShapefilePath, requestMethod = 'GET' }) => {
   const appContext = useContext(AppContext);
   const { state: mapState } = useMapContext();
-  const { state: filterState } = useFilterContext();
+  const { state: filterState, dispatch: filterDispatch } = useFilterContext();
   const [isDownloading, setIsDownloading] = useState(false);
   const [isShapefileDownloading, setIsShapefileDownloading] = useState(false);
   const [requestError, setRequestError] = useState(null);
@@ -86,9 +86,9 @@ export const SelectorSection = ({ filters, onFilterChange, bgColor, downloadPath
   const apiRouteShapefile = downloadShapefilePath;
   const requiresAuthShapefile = checkSecurityRequirements(apiSchema, apiRouteShapefile);
 
-  const handleFilterChange = (filter, value) => {
+  const handleFilterChange = useCallback((filter, value) => {
     onFilterChange(filter, value);
-  };
+  }, [filterDispatch]);
 
   const handleDownload = async () => {
     setIsDownloading(true);
@@ -264,7 +264,7 @@ export const SelectorSection = ({ filters, onFilterChange, bgColor, downloadPath
                       key={filter.id}
                       filter={filter}
                       value={filterState[filter.id]}
-                      onChange={(filter, value) => handleFilterChange(filter, value)}
+                      onChange={handleFilterChange}
                     />
                   )}
                   {filter.type === "slider" && (
@@ -272,7 +272,7 @@ export const SelectorSection = ({ filters, onFilterChange, bgColor, downloadPath
                       key={filter.id}
                       filter={filter}
                       value={filterState[filter.id] || filter.min || filter.values[0]}
-                      onChange={(filter, value) => handleFilterChange(filter, value)}
+                      onChange={handleFilterChange}
                     />
                   )}
                   {filter.type === "toggle" && (
@@ -283,7 +283,7 @@ export const SelectorSection = ({ filters, onFilterChange, bgColor, downloadPath
                         filterState[filter.id] ||
                         filter.values.values[0].paramValue
                       }
-                      onChange={(filter, value) => handleFilterChange(filter, value)}
+                      onChange={handleFilterChange}
                       bgColor={bgColor}
                     />
                   )}
@@ -295,7 +295,7 @@ export const SelectorSection = ({ filters, onFilterChange, bgColor, downloadPath
                         filterState[filter.id] ||
                         filter.values.values[0].paramValue
                       }
-                      onChange={(filter, value) => handleFilterChange(filter, value)}
+                      onChange={handleFilterChange}
                       bgColor={bgColor}
                     />
                   )}
@@ -304,7 +304,7 @@ export const SelectorSection = ({ filters, onFilterChange, bgColor, downloadPath
                       key={filter.id}
                       filter={filter}
                       value={filterState[filter.id]}
-                      onChange={(filter, value) => handleFilterChange(filter, value)}
+                      onChange={handleFilterChange}
                       bgColor={bgColor}
                     />
                   )}
@@ -313,7 +313,7 @@ export const SelectorSection = ({ filters, onFilterChange, bgColor, downloadPath
                       key={filter.id}
                       filter={filter}
                       value={filterState[filter.id]}
-                      onChange={(filter, value) => handleFilterChange(filter, value)}
+                      onChange={handleFilterChange}
                       bgColor={bgColor}
                     />
                   )}
@@ -322,7 +322,7 @@ export const SelectorSection = ({ filters, onFilterChange, bgColor, downloadPath
                       key={filter.id}
                       filter={filter}
                       value={filterState[filter.id]}
-                      onChange={(filter, value) => handleFilterChange(filter, value)}
+                      onChange={handleFilterChange}
                       bgColor={bgColor}
                     />
                   )}

--- a/packages/vis-core/src/Components/Sidebar/Sidebar.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Sidebar.jsx
@@ -271,7 +271,7 @@ export const Sidebar = ({
         {filters && Array.isArray(filters) && filters.length > 0 && (
           <SelectorSection
             filters={filters}
-            onFilterChange={(filter, value) => onFilterChange(filter, value)}
+            onFilterChange={onFilterChange}
             bgColor={bgColor}
             downloadPath={downloadPath}
             downloadShapefilePath = {downloadShapefilePath}

--- a/packages/vis-core/src/Components/Sidebar/Sidebar.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Sidebar.jsx
@@ -51,12 +51,25 @@ const SidebarContainer = styled.div`
     top: auto;
     max-width: 100%;
     width: 100%;
-    max-haight: none;
+    max-height: none;
     border-radius: 0;
     box-shadow: none;
-    overflow-y: auto;
     z-index: 1001;
-    display: ${({ $isVisible }) => ($isVisible ? 'block' : 'none')};
+    display: block;
+    
+    ${({ $isVisible }) => !$isVisible ? `
+      height: 0;
+      overflow: hidden;
+      padding-top: 0;
+      padding-bottom: 0;
+      margin: 0;
+      border: none;
+      opacity: 0;
+    ` : `
+      height: auto;
+      overflow-y: auto;
+      opacity: 1;
+    `}
   }
 
   /* Custom Scrollbar Styles for non-Firefox browsers */


### PR DESCRIPTION
## Summary

This PR fixes unnecessary rerender/effect churn in the sidebar dropdown path, especially for multiselect filters, and resolves a layout bug on mobile where multiselect chips were not rendering on initialisation.

## Changes

- Memoise the main filter-change callback in `MapLayout`.
- Pass stable `onFilterChange`/`onChange` callbacks through `Sidebar`, `SelectorSection`, and selector components instead of recreating inline functions
on every render.
- Refactor map filter action payload construction so scalar and multiselect values are handled consistently.
- Support multiselect values when building `UPDATE_COLOR_SCHEME` payloads instead of assuming the filter value is always scalar.
- Narrow the multiselect dropdown pruning effect dependencies so it only runs when the selected value or option validity actually changes.
- Fix an issue in `Sidebar.jsx` on mobile views where multiselect chips failed to display when initialised. This was resolved by replacing `display:
none` with a `height: 0; overflow: hidden` technique, ensuring `react-select` maintains its DOM flow dimensions to calculate chip layout correctly while
hidden.
- Fix a minor CSS typo (`max-haight`) in the mobile sidebar container styles.

## Why

- The dropdown render chain was recreating callback props on each render. That caused dropdown effects to retrigger unnecessarily and could interfere
with multiselect behaviour.
- `react-select` requires valid container dimensions upon mounting to wrap or display multiselect chips properly. Because the sidebar initialises in a
collapsed state on mobile, `display: none` caused width calculations to default to 0, permanently hiding the chips until re-rendered.

## Testing

Tests added/updated for:

- `MapLayout`