### PR TITLE
Dropdown sort by third column

### DIFF
--- a/packages/vis-core/docs/Metadata Filters Documentation.md
+++ b/packages/vis-core/docs/Metadata Filters Documentation.md
@@ -1,0 +1,45 @@
+# Metadata Driven Filters Documentation
+
+Filters in `vis-core` can be driven by metadata tables fetched at runtime. This allows dropdowns and selectors to be populated dynamically based on data available in the system.
+
+## Filter Configuration (`values` block)
+
+When defining a filter that uses a metadata table, the `values` object within the filter configuration provides the mapping between the tabular data and the dropdown options.
+
+### Properties
+
+- `source`: Must be set to `"metadataTable"`.
+- `metadataTableName`: The name of the metadata table configured in `pageContext.config.metadataTables`.
+- `displayColumn`: The column in the metadata table containing the label to display in the dropdown.
+- `paramColumn`: The column containing the underlying value passed to the filter state.
+- `legendSubtitleTextColumn` (optional): A column containing subtitle text for the legend when this option is selected.
+- `infoOnHoverColumn` (optional): A column containing tooltip text to display on hover.
+- `infoBelowOnChangeColumn` (optional): A column containing informational text to display below the selector.
+- `sort` (optional): Defines the sorting order. Accepts `"ascending"` or `"descending"`. If omitted, options will remain in the order they appear in the original metadata table.
+- `sortColumn` (optional): The column containing values to use for sorting (e.g., an index or priority column). If defined alongside `sort`, the dropdown options will be ordered according to this column. If omitted, sorting defaults to the text in `displayColumn`.
+- `where` (optional): An array of condition objects to filter the rows before populating options.
+- `exclude` (optional): An array of `paramValue`s to exclude from the dropdown.
+
+### Example Configuration
+
+```json
+{
+  "filterName": "Select Local Authority",
+  "paramName": "local_authority",
+  "type": "dropdown",
+  "values": {
+    "source": "metadataTable",
+    "metadataTableName": "authorities_metadata",
+    "displayColumn": "authority_name",
+    "paramColumn": "authority_id",
+    "sortColumn": "display_order",
+    "sort": "ascending"
+  }
+}
+```
+
+### Sorting Behavior
+
+1. **Original Table Order**: If `sort` is **omitted**, the dropdown will populate in the exact order the rows appear in the metadata table (deduplicated).
+2. **Alphabetical/Numeric Sort**: If `sort` is set to `"ascending"` or `"descending"` and `sortColumn` is **omitted**, the options will be sorted alphabetically/numerically by their `displayColumn` text.
+3. **Custom Column Sort**: If both `sort` and `sortColumn` are provided, the options will be sorted based on the numeric or text values in the `sortColumn`.

--- a/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
+++ b/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
@@ -125,6 +125,7 @@ export function useMetadataDrivenFilters({ getInitialValue = null } = {}) {
             legendSubtitleText: row[filter.values?.legendSubtitleTextColumn] || null,
             infoOnHover: row[filter.values?.infoOnHoverColumn] ?? null,
             infoBelowOnChange: row[filter.values?.infoBelowOnChangeColumn] ?? null,
+            sortValue: filter.values.sortColumn ? row[filter.values.sortColumn] : undefined,
           };
           // Deduplicate on (displayValue, paramValue)
           if (!options.some((o) => o.paramValue === value.paramValue && o.displayValue === value.displayValue)) {

--- a/packages/vis-core/src/hooks/useMetadataDrivenFilters.test.jsx
+++ b/packages/vis-core/src/hooks/useMetadataDrivenFilters.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { FilterContext, PageContext } from 'contexts';
+import { api } from 'services';
+import { useMetadataDrivenFilters } from './useMetadataDrivenFilters';
+
+jest.mock('services', () => ({
+  api: {
+    baseService: {
+      get: jest.fn(),
+      post: jest.fn(),
+    },
+  },
+}));
+
+describe('useMetadataDrivenFilters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sorts metadata table options by numeric-like sortColumn values', async () => {
+    api.baseService.get.mockResolvedValue([
+      { id: 'alpha', name: 'Alpha', display_order: '10' },
+      { id: 'zebra', name: 'Zebra', display_order: '1' },
+      { id: 'middle', name: 'Middle', display_order: '2' },
+    ]);
+
+    const pageContext = {
+      config: {
+        metadataTables: [
+          { name: 'dropdown_options', path: '/metadata/dropdown-options' },
+        ],
+        filters: [
+          {
+            filterName: 'Example filter',
+            paramName: 'example_filter',
+            type: 'dropdown',
+            values: {
+              source: 'metadataTable',
+              metadataTableName: 'dropdown_options',
+              displayColumn: 'name',
+              paramColumn: 'id',
+              sortColumn: 'display_order',
+              sort: 'ascending',
+            },
+          },
+        ],
+      },
+    };
+
+    const filterDispatch = jest.fn();
+    const wrapper = ({ children }) => (
+      <PageContext.Provider value={pageContext}>
+        <FilterContext.Provider value={{ state: {}, dispatch: filterDispatch }}>
+          {children}
+        </FilterContext.Provider>
+      </PageContext.Provider>
+    );
+
+    const { result } = renderHook(() => useMetadataDrivenFilters(), { wrapper });
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    expect(result.current.filters[0].values.values.map((value) => value.displayValue)).toEqual([
+      'Zebra',
+      'Middle',
+      'Alpha',
+    ]);
+    expect(filterDispatch).toHaveBeenCalledWith({
+      type: 'INITIALIZE_FILTERS',
+      payload: expect.objectContaining({ [result.current.filters[0].id]: 'zebra' }),
+    });
+  });
+});

--- a/packages/vis-core/src/utils/math.js
+++ b/packages/vis-core/src/utils/math.js
@@ -106,6 +106,16 @@ export const roundValue = (value) => {
   }
 };
 
+const normaliseSortValue = (value) => {
+  if (typeof value !== 'string') return value;
+
+  const trimmed = value.trim();
+  if (trimmed === '') return value;
+
+  const numericValue = Number(trimmed);
+  return Number.isFinite(numericValue) ? numericValue : value;
+};
+
 /**
  * Helper function to sort values based on the specified order.
  * @function sortValues
@@ -115,8 +125,8 @@ export const roundValue = (value) => {
  */
 export const sortValues = (values, order) => {
   return values.sort((a, b) => {
-    const valA = a.sortValue !== undefined ? a.sortValue : a.displayValue;
-    const valB = b.sortValue !== undefined ? b.sortValue : b.displayValue;
+    const valA = normaliseSortValue(a.sortValue !== undefined ? a.sortValue : a.displayValue);
+    const valB = normaliseSortValue(b.sortValue !== undefined ? b.sortValue : b.displayValue);
 
     if (order === 'ascending') {
       return valA > valB ? 1 : (valA < valB ? -1 : 0);

--- a/packages/vis-core/src/utils/math.js
+++ b/packages/vis-core/src/utils/math.js
@@ -115,10 +115,13 @@ export const roundValue = (value) => {
  */
 export const sortValues = (values, order) => {
   return values.sort((a, b) => {
+    const valA = a.sortValue !== undefined ? a.sortValue : a.displayValue;
+    const valB = b.sortValue !== undefined ? b.sortValue : b.displayValue;
+
     if (order === 'ascending') {
-      return a.displayValue > b.displayValue ? 1 : -1;
+      return valA > valB ? 1 : (valA < valB ? -1 : 0);
     } else if (order === 'descending') {
-      return a.displayValue < b.displayValue ? 1 : -1;
+      return valA < valB ? 1 : (valA > valB ? -1 : 0);
     }
     return 0;
   });

--- a/packages/vis-core/src/utils/math.test.js
+++ b/packages/vis-core/src/utils/math.test.js
@@ -1,0 +1,87 @@
+import { sortValues } from './math';
+
+describe('sortValues', () => {
+  it('sorts by displayValue in ascending order', () => {
+    const values = [
+      { displayValue: 'Banana', paramValue: 'banana' },
+      { displayValue: 'Apple', paramValue: 'apple' },
+      { displayValue: 'Cherry', paramValue: 'cherry' },
+    ];
+
+    expect(sortValues(values, 'ascending').map((value) => value.displayValue)).toEqual([
+      'Apple',
+      'Banana',
+      'Cherry',
+    ]);
+  });
+
+  it('sorts by displayValue in descending order', () => {
+    const values = [
+      { displayValue: 'Apple', paramValue: 'apple' },
+      { displayValue: 'Cherry', paramValue: 'cherry' },
+      { displayValue: 'Banana', paramValue: 'banana' },
+    ];
+
+    expect(sortValues(values, 'descending').map((value) => value.displayValue)).toEqual([
+      'Cherry',
+      'Banana',
+      'Apple',
+    ]);
+  });
+
+  it('sorts numeric-like displayValue strings numerically', () => {
+    const values = [
+      { displayValue: '10', paramValue: 10 },
+      { displayValue: '1', paramValue: 1 },
+      { displayValue: '2', paramValue: 2 },
+    ];
+
+    expect(sortValues(values, 'ascending').map((value) => value.displayValue)).toEqual([
+      '1',
+      '2',
+      '10',
+    ]);
+  });
+
+  it('sorts by numeric-like sortValue strings when provided', () => {
+    const values = [
+      { displayValue: 'Tenth', paramValue: 'tenth', sortValue: '10' },
+      { displayValue: 'First', paramValue: 'first', sortValue: '1' },
+      { displayValue: 'Second', paramValue: 'second', sortValue: '2' },
+    ];
+
+    expect(sortValues(values, 'ascending').map((value) => value.displayValue)).toEqual([
+      'First',
+      'Second',
+      'Tenth',
+    ]);
+  });
+
+  it('sorts by numeric-like sortValue strings in descending order', () => {
+    const values = [
+      { displayValue: 'First', paramValue: 'first', sortValue: '1' },
+      { displayValue: 'Tenth', paramValue: 'tenth', sortValue: '10' },
+      { displayValue: 'Second', paramValue: 'second', sortValue: '2' },
+    ];
+
+    expect(sortValues(values, 'descending').map((value) => value.displayValue)).toEqual([
+      'Tenth',
+      'Second',
+      'First',
+    ]);
+  });
+
+  it('falls back to displayValue when sortValue is not provided', () => {
+    const values = [
+      { displayValue: 'C', paramValue: 'c' },
+      { displayValue: 'A', paramValue: 'a' },
+      { displayValue: 'B', paramValue: 'b' },
+    ];
+
+    expect(sortValues(values, 'ascending').map((value) => value.displayValue)).toEqual([
+      'A',
+      'B',
+      'C',
+    ]);
+  });
+});


### PR DESCRIPTION
### Summary  
Adds support for sorting metadata-driven filter dropdown options by a configured `sortColumn`, including numeric-like values such as "1", "2", and "10".

### Changes  
- Added `sortColumn` handling when building metadata-table filter options in `useMetadataDrivenFilters`.
- Updated `sortValues` to use `sortValue` when present, falling back to `displayValue`.  
- Added numeric-like string normalisation so sort values compare numerically where appropriate.
- Added metadata filter documentation covering `sort`, `sortColumn`, and expected sorting behaviour.
- Added unit coverage for `sortValues`.
- Added hook-level coverage proving metadata-table filters sort by numeric-like `sortColumn` values.

### Why
Metadata-driven dropdowns sometimes need to follow an explicit display order from the metadata table rather than alphabetical order. This allows config authors to define stable custom ordering using an index, priority, or other sort column while preserving existing display-value sorting when no `sortColumn` is provided.

### Testing  
- Unit tests have been added; all passing