### PR TITLE
feat: cache metadata tables locally across pages

### DIFF
--- a/packages/vis-core/src/Components/MapLayout/Layer.jsx
+++ b/packages/vis-core/src/Components/MapLayout/Layer.jsx
@@ -109,9 +109,13 @@ export const Layer = ({ layer }) => {
         layerConfig.paint = layer.customPaint || layerConfig.paint;
 
         // Apply defaultOpacity to the layer's paint properties if specified
-        if (layer.defaultOpacity) {
-          const opacityProp = getOpacityProperty(layerConfig.type);
-          if (layerConfig.paint && opacityProp) {
+        const opacityProp = getOpacityProperty(layerConfig.type);
+        if (layerConfig.paint && opacityProp) {
+          if (layer.isStylable) {
+            // For stylable layers, start them with opacity 0 to prevent flashing
+            // before MapVisualisation applies the actual data-driven style
+            layerConfig.paint[opacityProp] = 0;
+          } else if (layer.defaultOpacity) {
             layerConfig.paint[opacityProp] = layer.defaultOpacity;
           }
         }
@@ -185,9 +189,11 @@ export const Layer = ({ layer }) => {
           lastTilesUrlByMapRef.current.set(mapInstance, url);
           
           // Apply defaultOpacity to tile layer paint properties if specified
-          if (layer.defaultOpacity) {
-            const opacityProp = getOpacityProperty(layerConfig.type);
-            if (layerConfig.paint && opacityProp) {
+          const opacityProp = getOpacityProperty(layerConfig.type);
+          if (layerConfig.paint && opacityProp) {
+            if (layer.isStylable) {
+              layerConfig.paint[opacityProp] = 0;
+            } else if (layer.defaultOpacity) {
               layerConfig.paint[opacityProp] = layer.defaultOpacity;
             }
           }
@@ -382,9 +388,11 @@ export const Layer = ({ layer }) => {
       };
 
       // Apply defaultOpacity if specified.
-      if (layer.defaultOpacity) {
-        const opacityProp = getOpacityProperty(baseLayerConfig.type);
-        if (baseLayerConfig.paint && opacityProp) {
+      const opacityProp = getOpacityProperty(baseLayerConfig.type);
+      if (baseLayerConfig.paint && opacityProp) {
+        if (layer.isStylable) {
+          baseLayerConfig.paint[opacityProp] = 0;
+        } else if (layer.defaultOpacity) {
           baseLayerConfig.paint[opacityProp] = layer.defaultOpacity;
         }
       }
@@ -432,7 +440,7 @@ export const Layer = ({ layer }) => {
       }
       if (Object.keys(filters).length > 0) {
         requestUrl = url.replace(/\{(\w+)\}/g, (_, key) => {
-          const uuid = paramNameToUuidMap[key];
+          const uuid = paramNameToUuidMap?.[key];
           return uuid && filters[uuid] !== undefined ? filters[uuid] : `{${key}}`;
         });
         dispatch({

--- a/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
+++ b/packages/vis-core/src/Components/MapLayout/MapLayout.jsx
@@ -59,7 +59,6 @@ const MobileLegendSlot = styled.section`
 export const MapLayout = () => {
   const { state, dispatch } = useMapContext();
   const { state: filterState, dispatch: filterDispatch } = useFilterContext();
-  const isLoading = state.isLoading || state.visualisationLoadingCount > 0;
   const isDynamicStylingLoading = state.isDynamicStylingLoading;
   const pageContext = useContext(PageContext);
   const initializedRef = useRef(false);
@@ -71,6 +70,26 @@ export const MapLayout = () => {
   // UPDATE_COLOR_SCHEME, etc.) so repaints and data fetches fire together rather than
   // immediately on each selector interaction. Selector UI still updates from the live filterState.
   const debouncedFilterState = useDebounced(filterState, 400);
+
+  const isFiltersDebouncing = debouncedFilterState !== filterState;
+  
+  // We keep the dimmer on if filters are debouncing.
+  // We also use a small 50ms buffer state for transitioning out of loading, 
+  // to prevent a 1-frame micro-gap flash between the debounce resolving and 
+  // the visualisations registering their loading state.
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const isCurrentlyLoading = state.isLoading || state.visualisationLoadingCount > 0 || isFiltersDebouncing;
+  
+  useEffect(() => {
+    if (isCurrentlyLoading) {
+      setIsTransitioning(true);
+    } else {
+      const timer = setTimeout(() => setIsTransitioning(false), 50);
+      return () => clearTimeout(timer);
+    }
+  }, [isCurrentlyLoading]);
+
+  const isLoading = isCurrentlyLoading || isTransitioning;
 
   useEffect(() => {
     if (!initializedRef.current && state.pageIsReady) {

--- a/packages/vis-core/src/contexts/MapContext.jsx
+++ b/packages/vis-core/src/contexts/MapContext.jsx
@@ -352,7 +352,10 @@ export const MapProvider = ({ children }) => {
 
   return (
     <MapContext.Provider value={contextValue}>
-      {state.pageIsReady ? children : <div>Loading...</div>}
+      {/* We no longer conditionally hide children based on pageIsReady. 
+          This prevents MapLibre from unmounting/remounting, 
+          letting MapLayout's internal Dimmer handle the loading state instead. */}
+      {children}
     </MapContext.Provider>
   );
 };

--- a/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
+++ b/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
@@ -24,6 +24,41 @@ async function callMetadataEndpoint(endpoint) {
   return api.baseService.get(endpoint.path, opts);
 }
 
+const metadataPromiseCache = new Map();
+
+/**
+ * Executes a GET or POST request for a metadata table and caches the resulting Promise.
+ * This prevents duplicate concurrent network requests for the same metadata table and 
+ * caches the result across page transitions that share the same metadata requirements.
+ *
+ * @param {Object} endpoint - The endpoint configuration object.
+ * @param {string} endpoint.path - The API path for the metadata table.
+ * @param {'GET'|'POST'} [endpoint.requestMethod='GET'] - The HTTP method to use.
+ * @param {Object} [endpoint.requestOptions] - Additional fetch options.
+ * @param {Object} [endpoint.body] - The request body for POST requests.
+ * @returns {Promise<any>} A Promise that resolves to the parsed response payload.
+ * @throws {Error} Propagates API errors and automatically invalidates the failed cache entry.
+ */
+async function callMetadataEndpointWithCache(endpoint) {
+  const cacheKey = JSON.stringify({
+    path: endpoint.path,
+    method: (endpoint.requestMethod || "GET").toUpperCase(),
+    body: endpoint.body || {}
+  });
+
+  if (metadataPromiseCache.has(cacheKey)) {
+    return metadataPromiseCache.get(cacheKey);
+  }
+
+  const promise = callMetadataEndpoint(endpoint).catch((err) => {
+    metadataPromiseCache.delete(cacheKey);
+    throw err;
+  });
+
+  metadataPromiseCache.set(cacheKey, promise);
+  return promise;
+}
+
 /**
  * useMetadataDrivenFilters
  * Canonical filter initialisation pipeline. Handles metadata table fetching, filter option
@@ -65,7 +100,7 @@ export function useMetadataDrivenFilters({ getInitialValue = null } = {}) {
         const tables = {};
         const empty = [];
         for (const table of pageContext.config.metadataTables || []) {
-          const response = await callMetadataEndpoint(table);
+          const response = await callMetadataEndpointWithCache(table);
           let rows = response;
           if (Array.isArray(table.where) && table.where.length > 0) {
             rows = applyWhereConditions(rows, table.where);

--- a/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
+++ b/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
@@ -24,12 +24,14 @@ async function callMetadataEndpoint(endpoint) {
   return api.baseService.get(endpoint.path, opts);
 }
 
+const METADATA_CACHE_KEY_PREFIX = "metadata_cache_";
 const metadataPromiseCache = new Map();
 
 /**
  * Executes a GET or POST request for a metadata table and caches the resulting Promise.
  * This prevents duplicate concurrent network requests for the same metadata table and 
  * caches the result across page transitions that share the same metadata requirements.
+ * Data is also persisted to sessionStorage to survive hard page reloads during a session.
  *
  * @param {Object} endpoint - The endpoint configuration object.
  * @param {string} endpoint.path - The API path for the metadata table.
@@ -46,14 +48,36 @@ async function callMetadataEndpointWithCache(endpoint) {
     body: endpoint.body || {}
   });
 
+  // 1. Check in-memory promise cache (prevents duplicate simultaneous requests)
   if (metadataPromiseCache.has(cacheKey)) {
     return metadataPromiseCache.get(cacheKey);
   }
 
-  const promise = callMetadataEndpoint(endpoint).catch((err) => {
-    metadataPromiseCache.delete(cacheKey);
-    throw err;
-  });
+  // 2. Check sessionStorage for persisted data from previous visits
+  const storageKey = METADATA_CACHE_KEY_PREFIX + cacheKey;
+  const storedData = sessionStorage.getItem(storageKey);
+  if (storedData) {
+    try {
+      return JSON.parse(storedData);
+    } catch (e) {
+      console.warn("Failed to parse cached metadata from sessionStorage", e);
+    }
+  }
+
+  // 3. Fetch from network and cache
+  const promise = callMetadataEndpoint(endpoint)
+    .then((data) => {
+      try {
+        sessionStorage.setItem(storageKey, JSON.stringify(data));
+      } catch (e) {
+        console.warn("Failed to persist metadata to sessionStorage. Quota exceeded?", e);
+      }
+      return data;
+    })
+    .catch((err) => {
+      metadataPromiseCache.delete(cacheKey);
+      throw err;
+    });
 
   metadataPromiseCache.set(cacheKey, promise);
   return promise;

--- a/packages/vis-core/src/services/api/Base.js
+++ b/packages/vis-core/src/services/api/Base.js
@@ -211,7 +211,9 @@ class BaseService {
       ...addOptions,
     };
     const result = await fetch(url, options).catch((error) => {
-      console.log(error);
+      if (error.name !== 'AbortError') {
+        console.log(error);
+      }
       throw error;
     });
     if (!result.ok) {
@@ -280,7 +282,9 @@ class BaseService {
       ...addOptions,
     };
     const result = await fetch(url, options).catch((error) => {
-      console.log(error);
+      if (error.name !== 'AbortError') {
+        console.log(error);
+      }
       throw error;
     });
     if (!result.ok) {


### PR DESCRIPTION
## Summary
This pull request introduces significant perceived performance improvements to the initial map page render by preventing unnecessary unmounting of the MapLibre context. It also addresses several disruptive bugs that occurred during page transitions, including layer flashing, spurious console errors, and application crashes.

Relates to #259 

## Changes
* added `metadataPromiseCache` to `useMetadataDrivenFilters.jsx` to cache the promises of network requests, preventing concurrent duplicate API calls. Data is also persisted to `sessionStorage` to survive hard browser reloads.
* updated `MapContext.jsx` so that the `MapLayout` is no longer conditionally hidden when the page is not ready. The loading state is now entirely managed by `Dimmer`.
* updated `MapLayout` so Dimmer stays active while filters are debouncing
* added an optional chaining check (`paramNameToUuidMap?.[key]`) in `Layer.jsx` to prevent a `TypeError` from throwing when the layout attempts to re-render before the new page's filter context is fully initialised
* modified `Layer.jsx` to mount any data-driven (`isStylable`) layer initial opacity to `0` to prevent flashing (subsequent styling will reset it)

## Why
Previously, changing map pages would destroy the MapLibre context and completely re-initialise it. This resulted in a lengthy "Loading..." screen at the top of a blank page - particularly if metadata tables are laggy - providing a poor user experience. Keeping the map mounted and masking it with the dimmer during data loads appears far more performant. Using a metadata cache ensures page switching is as fast as possible.