### PR TITLE
feat: make dynamic legend default display mode configurable

### DIFF
--- a/packages/vis-core/docs/Legend display mode configuration.md
+++ b/packages/vis-core/docs/Legend display mode configuration.md
@@ -1,0 +1,50 @@
+# Configuring the dynamic legend display mode
+
+The dynamic legend supports two display modes for numeric data: continuous gradients and discrete swatches. By default, the system applies the continuous gradient bar where possible. You can override this default behaviour to present discrete swatches initially. 
+
+Users can manually toggle between continuous and discrete modes using the settings icon on the legend. User selections are saved to local storage and take precedence over default application or layer configurations.
+
+## App level configuration
+
+You can set a default display mode for all map layers within an application. This is defined in the `appConfig.js` file for the specific application.
+
+Provide the `defaultLegendDisplayMode` property at the root of the configuration object. The accepted values are `continuous` and `discrete`.
+
+```javascript
+export const appConfig = {
+  // Other app configurations...
+  defaultLegendDisplayMode: 'discrete', 
+};
+```
+
+If omitted, the fallback behaviour is `continuous`.
+
+## Layer level configuration
+
+You can override the app level default for individual map layers. This is useful when most layers should display as discrete swatches, but a specific layer requires a continuous gradient.
+
+Add the `defaultLegendDisplayMode` property to the `metadata` object within the layer's definition in your map configuration. 
+
+```json
+{
+  "id": "example-heatmap-layer",
+  "type": "fill",
+  "source": "example-source",
+  "metadata": {
+    "isStylable": true,
+    "defaultLegendDisplayMode": "continuous"
+  },
+  "paint": {
+    // Paint properties...
+  }
+}
+```
+
+## Configuration precedence
+
+The legend display mode is determined using the following hierarchy, from highest to lowest priority:
+
+1. User preference (saved to local storage via the legend settings interface)
+2. Layer level configuration (`layer.metadata.defaultLegendDisplayMode`)
+3. App level configuration (`appConfig.defaultLegendDisplayMode`)
+4. System default (`continuous`)

--- a/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.jsx
+++ b/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.jsx
@@ -30,7 +30,7 @@ export const DynamicLegend = ({ map }) => {
   const isMobile = useIsMobile();
   const [legendItems, setLegendItems] = useState([]);
   const { state } = useMapContext();
-  const { defaultBands } = useAppContext();
+  const { defaultBands, defaultLegendDisplayMode = 'continuous' } = useAppContext();
   // Initialise from localStorage so the user's display/scale preferences survive
   // page refreshes and navigation. Falls back to an empty object if storage is
   // unavailable (private browsing, quota exceeded, etc.).
@@ -76,9 +76,9 @@ export const DynamicLegend = ({ map }) => {
     setOpenPopoverId(prev => prev === layerId ? null : layerId);
   };
 
-  const updateLayerPref = (layerId, key, value) => {
+  const updateLayerPref = (layerId, key, value, defaultDisplayMode = 'continuous') => {
     setLayerPrefs(prev => {
-      const currentPref = prev[layerId] || { displayMode: 'continuous', scaleMode: 'value' };
+      const currentPref = prev[layerId] || { displayMode: defaultDisplayMode, scaleMode: 'value' };
       const next = { ...prev, [layerId]: { ...currentPref, [key]: value } };
       // Persist to localStorage so preferences survive page refreshes.
       try {
@@ -368,6 +368,7 @@ export const DynamicLegend = ({ map }) => {
           }
 
           const legendNumericEntries = filteredEntries.map(e => e.numericValue);
+          const layerDefaultDisplayMode = layer.metadata?.defaultLegendDisplayMode || defaultLegendDisplayMode;
           
           return {
             layerId: layer.id,
@@ -375,6 +376,7 @@ export const DynamicLegend = ({ map }) => {
             subtitle: legendSubtitleText,
             legendEntries: filteredEntries,
             legendEntriesNumeric: legendNumericEntries,
+            defaultDisplayMode: layerDefaultDisplayMode,
             // legendAnnotations: { start, end } — positional (left/right) annotation
             // strings for the continuous gradient bar. Present only when the layer
             // config declares them; undefined otherwise.

--- a/packages/vis-core/src/Components/DynamicLegend/LegendLayerGroup.jsx
+++ b/packages/vis-core/src/Components/DynamicLegend/LegendLayerGroup.jsx
@@ -114,7 +114,7 @@ const LegendLayerGroup = ({
   const numericVals = item.legendEntriesNumeric?.filter(Number.isFinite) || [];
   const isDescending = numericVals.length >= 2 && numericVals[0] > numericVals[numericVals.length - 1];
 
-  const pref = layerPrefs[item.layerId] || { displayMode: 'continuous', scaleMode: 'value' };
+  const pref = layerPrefs[item.layerId] || { displayMode: item.defaultDisplayMode || 'continuous', scaleMode: 'value' };
   const useDiscreteSwatches = !canBeContinuous || pref.displayMode === 'discrete';
 
   const isPopoverOpen = openPopoverId === item.layerId;
@@ -165,7 +165,7 @@ const LegendLayerGroup = ({
                         <input
                           type="radio"
                           checked={pref.displayMode === 'continuous'}
-                          onChange={() => updateLayerPref(item.layerId, 'displayMode', 'continuous')}
+                          onChange={() => updateLayerPref(item.layerId, 'displayMode', 'continuous', item.defaultDisplayMode)}
                         />
                         Continuous bar
                       </label>
@@ -173,7 +173,7 @@ const LegendLayerGroup = ({
                         <input
                           type="radio"
                           checked={pref.displayMode === 'discrete'}
-                          onChange={() => updateLayerPref(item.layerId, 'displayMode', 'discrete')}
+                          onChange={() => updateLayerPref(item.layerId, 'displayMode', 'discrete', item.defaultDisplayMode)}
                         />
                         Discrete swatches
                       </label>
@@ -186,7 +186,7 @@ const LegendLayerGroup = ({
                             <input
                               type="radio"
                               checked={pref.scaleMode === 'value'}
-                              onChange={() => updateLayerPref(item.layerId, 'scaleMode', 'value')}
+                              onChange={() => updateLayerPref(item.layerId, 'scaleMode', 'value', item.defaultDisplayMode)}
                             />
                             Proportional to values
                           </label>
@@ -194,7 +194,7 @@ const LegendLayerGroup = ({
                             <input
                               type="radio"
                               checked={pref.scaleMode === 'color'}
-                              onChange={() => updateLayerPref(item.layerId, 'scaleMode', 'color')}
+                              onChange={() => updateLayerPref(item.layerId, 'scaleMode', 'color', item.defaultDisplayMode)}
                             />
                             Evenly spaced colours
                           </label>


### PR DESCRIPTION
This PR introduces the ability to configure the default display mode (continuous vs. discrete) for the DynamicLegend
component. Previously, the legend always defaulted to a continuous gradient bar.

Changes included:

* App-level configuration: Added support for a `defaultLegendDisplayMode `property in the application context (appConfig.js),
allowing applications to default all their layers to discrete swatches if desired.
* Layer-level overrides: Added support for a `defaultLegendDisplayMode `property within a layer's metadata configuration,
enabling per-layer overrides that take precedence over the app-level default.
* Backwards compatibility: Maintained the existing fallback to 'continuous' when no configurations are provided.
* User preference persistence: Ensured user display mode choices saved to localStorage (via the legend settings cog)
continue to take precedence over these new defaults.
* Documentation: Added a markdown guide (Legend display mode configuration.md) detailing how to apply these new
configuration options.