### PR TITLE
feat: link TfN logo to transportforthenorth.com

### DIFF
--- a/packages/vis-core/src/Components/Navbar/Navbar.jsx
+++ b/packages/vis-core/src/Components/Navbar/Navbar.jsx
@@ -10,7 +10,7 @@ import { Logo } from "./Logo";
 import { LateralNavbar } from "./LateralNavbar";
 import { ResponsiveNavbarLinks } from "./ResponsiveNavbarLinks";
 
-const TFN_WEBSITE_URL = "https://www.transportforthenorth.com/";
+const DEFAULT_TFN_WEBSITE_URL = "https://www.transportforthenorth.com/";
 
 const StyledNavbar = styled.nav`
   display: flex;
@@ -98,7 +98,8 @@ export function Navbar() {
   };
 
   const handleLogoClick = () => {
-    window.open(TFN_WEBSITE_URL, "_blank", "noopener,noreferrer");
+    const logoClickUrl = appContext.logoClickUrl || DEFAULT_TFN_WEBSITE_URL;
+    window.open(logoClickUrl, "_blank", "noopener,noreferrer");
   }
 
   const updateSideNav = () => {

--- a/packages/vis-core/src/Components/Navbar/Navbar.jsx
+++ b/packages/vis-core/src/Components/Navbar/Navbar.jsx
@@ -10,6 +10,8 @@ import { Logo } from "./Logo";
 import { LateralNavbar } from "./LateralNavbar";
 import { ResponsiveNavbarLinks } from "./ResponsiveNavbarLinks";
 
+const TFN_WEBSITE_URL = "https://www.transportforthenorth.com/";
+
 const StyledNavbar = styled.nav`
   display: flex;
   align-items: center;
@@ -95,6 +97,10 @@ export function Navbar() {
       setBgColor(navLinkBgColour);
   };
 
+  const handleLogoClick = () => {
+    window.open(TFN_WEBSITE_URL, "_blank", "noopener,noreferrer");
+  }
+
   const updateSideNav = () => {
     setSideNavOpen((prev) => !prev);
   };
@@ -153,7 +159,7 @@ export function Navbar() {
           {(!isMobile && logoPosition === "left") && (
             <Logo
               logoImage={logoImage}
-              onClick={() => onClick(null, logoImage)}
+              onClick={handleLogoClick}
               position="left"
             />
           )}
@@ -168,14 +174,14 @@ export function Navbar() {
           {(!isMobile && logoPosition === "right") && (
             <Logo
               logoImage={logoImage}
-              onClick={() => onClick(null, logoImage)}
+              onClick={handleLogoClick}
               position="right"
             />
           )}
           {isMobile && (
             <Logo
               logoImage={logoImage}
-              onClick={() => onClick(null, logoImage)}
+              onClick={handleLogoClick}
               position="left"
             />
           )}


### PR DESCRIPTION
# Changes
Logo click previously had no effect (onClick was called with a null url, so navigate() never fired). Added a dedicated handleLogoClick handler that opens the TfN website in a new tab, and wired it into all four Logo instances in Navbar.jsx.
- New tab (window.open with noopener,noreferrer) to avoid losing in-app state (map views, filters, scenario selections)
- URL: https://www.transportforthenorth.com/ — please confirm this is correct

Closes [#215](https://github.com/Transport-for-the-North/BRONTE-Visualisation-Framework/issues/215)
