### PR TITLE
Bronte Bug Fix - BRONTE-0022 and BRONTE-0008

### DIFF
--- a/packages/vis-core/src/Components/Sidebar/Selectors/Dropdown.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Selectors/Dropdown.jsx
@@ -5,7 +5,7 @@ import styled, { useTheme } from 'styled-components';
 import { ChevronRightIcon } from '@heroicons/react/20/solid';
 import { useFilterContext } from 'hooks';
 import { SelectorLabel } from '.';
-import { makeSelectStyles } from 'utils/selectStyles';
+import { makeSelectStyles, selectComponents } from 'utils/selectStyles';
 
 const CONTROL_COLOUR = 'rgb(220, 220, 220)';
 
@@ -177,12 +177,18 @@ export const Dropdown = ({ filter, onChange }) => {
   const selectStyles = useMemo(() => makeSelectStyles(theme), [theme]);
 
   const { state: filterState } = useFilterContext();
-  const animatedComponents = makeAnimated();
   const [loading, setLoading] = useState(false);
   const [isInfoCollapsed, setInfoCollapsed] = useState(false);
   const prevOptionsRef = useRef([]);
   const prevSelectedOptionsRef = useRef(null);
   const [isAllSelected, setIsAllSelected] = useState(false);
+  const animatedComponents = useMemo(
+    () => ({
+      ...makeAnimated(),
+      ...selectComponents,
+    }),
+    []
+  );
 
   const baseOptions = useMemo(() => {
     return filter.values.values

--- a/packages/vis-core/src/Components/Sidebar/Selectors/FeatureSelect.jsx
+++ b/packages/vis-core/src/Components/Sidebar/Selectors/FeatureSelect.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import Select, { components } from 'react-select';
 import styled, { useTheme } from 'styled-components';
 import { useLayerFeatureMetadata } from 'hooks/useLayerFeatureMetadata';
-import { makeSelectStyles } from 'utils/selectStyles';
+import { makeSelectStyles, selectComponents } from 'utils/selectStyles';
 
 // Styled components
 const Container = styled.div`
@@ -93,7 +93,7 @@ export const FeatureSelect = ({ layerPath, value, onChange, isMulti = false, pla
         isLoading={isLoading}
         noOptionsMessage={() => noOptionsMessage}
         onMenuOpen={handleMenuOpen}
-        components={{ ValueContainer: CustomValueContainer }}
+        components={{ ...selectComponents, ValueContainer: CustomValueContainer }}
         styles={selectStyles}
         menuPortalTarget={document.body}
         menuPosition="fixed"

--- a/packages/vis-core/src/hooks/useLayerFeatureMetadata.jsx
+++ b/packages/vis-core/src/hooks/useLayerFeatureMetadata.jsx
@@ -58,7 +58,13 @@ export const useLayerFeatureMetadata = (layerPath) => {
           .map((feature) => ({
             value: feature.id,
             label: feature.name || feature.id,
-          }));
+          }))
+          .sort((a, b) =>
+            String(a.label).localeCompare(String(b.label), undefined, {
+              numeric: true,
+              sensitivity: 'base',
+            })
+          );
 
         // Update the cache with the new result
         cache.current[cacheKey] = filteredOptions;

--- a/packages/vis-core/src/utils/selectStyles.js
+++ b/packages/vis-core/src/utils/selectStyles.js
@@ -1,5 +1,29 @@
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import { useTheme } from "styled-components";
+import { components } from "react-select";
+
+/**
+ * Shared react-select component overrides.
+ * Adds native browser tooltip support for truncated multi-value chips.
+ */
+export const selectComponents = {
+  MultiValueLabel: (props) => {
+    const label =
+      typeof props.data?.label === "string"
+        ? props.data.label
+        : typeof props.children === "string"
+          ? props.children
+          : "";
+
+    return React.createElement(components.MultiValueLabel, {
+      ...props,
+      innerProps: {
+        ...props.innerProps,
+        title: label,
+      },
+    });
+  },
+};
 
 /**
  * makeSelectStyles


### PR DESCRIPTION
# Changes

This PR addresses two BRONTE / vis-core dropdown usability issues:

**Closes**
-  #268 
-  #266 

# Tasks

**1. Multiselect chip tooltip support for truncated labels**

Added support for native browser tooltips on truncated multiselect chip labels by introducing a shared` react-select ``MultiValueLabel` override in `selectStyles.js` and wiring it into the relevant select components 

**Included**

- Added a shared `selectComponents `export in `selectStyles.js` to apply a native `title `attribute to multiselect chip labels 
- Updated multiselect dropdown call sites to opt into the shared component override so users can hover truncated chips and see the full label text.
- Preserved the existing visual layout and truncation behaviour — no custom tooltip styling or chip layout changes were introduced 

**Impact**
This resolves the issue where long selected values were truncated with ellipsis and there was no way to view the full selected label.

**2. Natural sorting for **“Zoom to feature”** dropdown values**

Updated the feature metadata loading flow to apply natural / numeric-aware sorting before pagination so numerically named and mixed text-number features appear in intuitive order.

**Included**

- Applied natural sort ordering to filtered feature options using `localeCompare(..., { numeric: true, sensitivity: "base" })` before storing paged results.
- Ensured sorting happens before caching and slicing so pagination remains stable and correctly ordered.
- Preserved existing search/filter behaviour and incremental loading logic.

**Impact**
This resolves the issue where feature names were effectively shown in dictionary / lexicographic order rather than natural numeric order.

Examples after fix:

`1, 2, 3, ..., 10, 11`

instead of:

`1, 10, 11, 2`

**Why**
These changes improve usability of dropdown-based interactions across the app by:

- making long multiselect chip labels inspectable without changing layout 
- making “Zoom to feature” navigation much more intuitive for zone IDs and mixed text-number feature names

Both fixes are scoped, low-risk UI behaviour improvements and do not alter API contracts or visual design.


- [ ] Verified multiselect chip hover shows full selected value text
- [ ] Verified “Zoom to feature” values sort naturally for numeric and mixed labels
- [ ] Confirmed no visual regressions to existing dropdown styling 
- [ ] Confirmed pagination / infinite scroll behaviour still works correctly for feature metadata lists
- [ ] Build / lint / checks pass