### PR TITLE
Add bulk POST support to fetchDetails and focusSummary field ty…

### DIFF
--- a/packages/vis-core/src/Components/DirectoryScorecardsPage/DirectoryScorecardsPage.jsx
+++ b/packages/vis-core/src/Components/DirectoryScorecardsPage/DirectoryScorecardsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { PageContext } from "contexts";
 import { useMetadataDrivenFilters } from "hooks/useMetadataDrivenFilters";
 import { DataTable } from "Components/DataTable";
@@ -66,9 +66,10 @@ export function DirectoryScorecardsPage() {
     return applyWhereConditions(records, where);
   }, [records, config.recordsEndpoint]);
 
-  const scopedRows = useMemo(
-    () => applyTopFilterScoping(clientScopedRecords, filters, filterState, isReady),
-    [clientScopedRecords, filters, filterState, isReady]
+  const scopedRows = useMemo(() => {
+    if (config.recordsEndpoint?.disableTopFilterScoping) return clientScopedRecords;
+    return applyTopFilterScoping(clientScopedRecords, filters, filterState, isReady);
+  }, [clientScopedRecords, filters, filterState, isReady, config.recordsEndpoint]
   );
 
   const idAccessor = config.selection?.rowIdAccessor || "id";
@@ -96,37 +97,78 @@ export function DirectoryScorecardsPage() {
 
   const [detailsCache, setDetailsCache] = useState({});
 
+  /**
+   * Signature of only the filter values that recordDetailsEndpoint.serverFilter
+   * actually maps into the request.
+   */
+  const detailsFilterSignature = useMemo(() => {
+    const serverFilter = config.recordDetailsEndpoint?.serverFilter;
+    const map = serverFilter?.paramMap;
+    if (!serverFilter?.enabled || !map) return null;
+
+    const relevantIds = filters.filter((f) => map[f.paramName]).map((f) => f.id);
+    return JSON.stringify(relevantIds.map((id) => filterState?.[id]));
+  }, [filters, filterState, config.recordDetailsEndpoint]);
+
+  const lastFetchSignatureRef = useRef(null);
+
   useEffect(() => {
     let cancelled = false;
 
     const ids = Array.from(selectedIds);
-    const missing = ids.filter((id) => !detailsCache[id]);
-    if (missing.length === 0) return;
+    const signatureChanged = lastFetchSignatureRef.current !== detailsFilterSignature;
+    const missing = signatureChanged ? ids : ids.filter((id) => !detailsCache[id]);
+
+    if (missing.length === 0) {
+      lastFetchSignatureRef.current = detailsFilterSignature;
+      return;
+    }
 
     (async () => {
       try {
-        const results = await Promise.all(
-          missing.map(async (id) => {
-            const payload = await api.endpointDefinitionClient.fetchDetails(
-              config.recordDetailsEndpoint,
-              {
-                idParamName: config.selection?.rowIdQueryParam || "run_id",
-                idValue: id,
-              }
-            );
-            return { id, payload };
-          })
-        );
+        const resultsById = {};
+        const detailsFetchMode = config.recordDetailsEndpoint?.detailsFetchMode;
+
+        if (detailsFetchMode === "bulk") {
+          const idsParamName = config.recordDetailsEndpoint?.idsRequestKey || "ids";
+          const payload = await api.endpointDefinitionClient.fetchDetails(
+            config.recordDetailsEndpoint,
+            { idParamName: idsParamName, idValues: missing },
+            filters,
+            filterState
+          );
+          Object.assign(resultsById, payload || {});
+        } else {
+          const results = await Promise.all(
+            missing.map(async (id) => {
+              const payload = await api.endpointDefinitionClient.fetchDetails(
+                config.recordDetailsEndpoint,
+                {
+                  idParamName: config.selection?.rowIdQueryParam || "run_id",
+                  idValue: id,
+                },
+                filters,
+                filterState
+              );
+              return { id, payload };
+            })
+          );
+          results.forEach(({ id, payload }) => {
+            resultsById[id] = payload;
+          });
+        }
 
         if (cancelled) return;
 
         setDetailsCache((prev) => {
-          const next = { ...prev };
-          results.forEach(({ id, payload }) => {
-            next[id] = payload;
+          const next = signatureChanged ? {} : { ...prev };
+          missing.forEach((id) => {
+            if (resultsById[id] !== undefined) next[id] = resultsById[id];
           });
           return next;
         });
+
+        lastFetchSignatureRef.current = detailsFilterSignature;
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error("DirectoryScorecardsPage: failed to load record details:", e);
@@ -137,7 +179,12 @@ export function DirectoryScorecardsPage() {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedIds, config.recordDetailsEndpoint, config.selection?.rowIdQueryParam]);
+  }, [
+    selectedIds,
+    detailsFilterSignature,
+    config.recordDetailsEndpoint,
+    config.selection?.rowIdQueryParam,
+  ]);
 
   const formatterRegistry = useMemo(() => config.formatters || {}, [config.formatters]);
   const panelsTemplate = useMemo(() => config.panels || [], [config.panels]);

--- a/packages/vis-core/src/Components/Scorecard/Scorecard.jsx
+++ b/packages/vis-core/src/Components/Scorecard/Scorecard.jsx
@@ -1,9 +1,12 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { getByPath } from "utils/getByPath";
 
 import {
+  BreakdownList,
   ContentWrapper,
   EmptyState,
+  FocusSummaryBlock,
+  FocusSummaryLabel,
   MetricLabel,
   MetricLabelStrong,
   MetricRow,
@@ -14,6 +17,9 @@ import {
   RemoveBtn,
   Section,
   SectionTitle,
+  SplitDimension,
+  SplitDimensionTitle,
+  ToggleBtn,
 } from "./Scorecard.styles";
 
 /**
@@ -21,6 +27,7 @@ import {
  * @property {string} label
  * @property {string} path - Dot-path into the `details` object.
  * @property {string} [format] - Key into the formatter registry.
+ * @property {"metric"|"focusSummary"} [type] - Defaults to "metric" when omitted.
  */
 
 /**
@@ -66,6 +73,108 @@ function formatValue(raw, spec) {
   });
 
   return fmt.format(num);
+}
+
+/**
+ * Renders a focus/north/rogb summary object with independently collapsible
+ * area (`focusItems`) and dimension (`splitBy`) breakdowns.
+ *
+ * Expects `value` shaped as:
+ * { focusTotal, focusItems: {[area]: number}, northTotal, rogbTotal,
+ *   splitBy: {[dimension]: {[label]: {focusTotal, ...}}} | null }
+ *
+ * @param {{ field: ScorecardField, value: any, formatterRegistry: Record<string, Intl.NumberFormatOptions> }} props
+ */
+function FocusSummaryField({ field, value, formatterRegistry }) {
+  const [showItems, setShowItems] = useState(false);
+  const [showSplit, setShowSplit] = useState(false);
+
+  const spec = formatterRegistry?.[field.format];
+  const fmt = (raw) => (spec ? formatValue(raw, spec) : raw ?? "-");
+
+  if (value == null) {
+    return (
+      <FocusSummaryBlock>
+        <MetricRow>
+          <MetricLabelStrong>{field.label}</MetricLabelStrong>
+          <MetricValue>-</MetricValue>
+        </MetricRow>
+      </FocusSummaryBlock>
+    );
+  }
+
+  const { focusTotal, focusItems, northTotal, rogbTotal, splitBy } = value;
+
+  const itemEntries = focusItems ? Object.entries(focusItems) : [];
+  const splitEntries = splitBy ? Object.entries(splitBy) : [];
+
+  return (
+    <FocusSummaryBlock>
+      <FocusSummaryLabel>{field.label}</FocusSummaryLabel>
+
+      <MetricRow>
+        <MetricLabelStrong>Focus Area</MetricLabelStrong>
+        <MetricValueStrong>{fmt(focusTotal)}</MetricValueStrong>
+      </MetricRow>
+      <MetricRow>
+        <MetricLabel>Rest of North</MetricLabel>
+        <MetricValue>{fmt(northTotal)}</MetricValue>
+      </MetricRow>
+      <MetricRow>
+        <MetricLabel>Rest of GB</MetricLabel>
+        <MetricValue>{fmt(rogbTotal)}</MetricValue>
+      </MetricRow>
+
+      {itemEntries.length > 0 && (
+        <>
+          <ToggleBtn
+            type="button"
+            aria-expanded={showItems}
+            onClick={() => setShowItems((v) => !v)}
+          >
+            {showItems ? "Hide" : "Show"} area breakdown ({itemEntries.length})
+          </ToggleBtn>
+          {showItems && (
+            <BreakdownList>
+              {itemEntries.map(([areaName, areaValue]) => (
+                <MetricRow key={areaName}>
+                  <MetricLabel>{areaName}</MetricLabel>
+                  <MetricValue>{fmt(areaValue)}</MetricValue>
+                </MetricRow>
+              ))}
+            </BreakdownList>
+          )}
+        </>
+      )}
+
+      {splitEntries.length > 0 && (
+        <>
+          <ToggleBtn
+            type="button"
+            aria-expanded={showSplit}
+            onClick={() => setShowSplit((v) => !v)}
+          >
+            {showSplit ? "Hide" : "Show"} split by ({splitEntries.length})
+          </ToggleBtn>
+          {showSplit && (
+            <BreakdownList>
+              {splitEntries.map(([dimensionName, labels]) => (
+                <SplitDimension key={dimensionName}>
+                  <SplitDimensionTitle>{dimensionName}</SplitDimensionTitle>
+                  {Object.entries(labels).map(([labelName, labelValue]) => (
+                    <MetricRow key={labelName}>
+                      <MetricLabel>{labelName}</MetricLabel>
+                      <MetricValue>{fmt(labelValue?.focusTotal)}</MetricValue>
+                    </MetricRow>
+                  ))}
+                </SplitDimension>
+              ))}
+            </BreakdownList>
+          )}
+        </>
+      )}
+    </FocusSummaryBlock>
+  );
 }
 
 /**
@@ -121,6 +230,18 @@ export function Scorecard({
               {(panel.fields || []).map((f, fIdx) => {
                 const spec = formatterRegistry?.[f.format];
                 const valueRaw = getByPath(details, f.path);
+
+                if (f.type === "focusSummary") {
+                  return (
+                    <FocusSummaryField
+                      key={fIdx}
+                      field={f}
+                      value={valueRaw}
+                      formatterRegistry={formatterRegistry}
+                    />
+                  );
+                }
+
                 const value = spec ? formatValue(valueRaw, spec) : valueRaw ?? "-";
 
                 return (

--- a/packages/vis-core/src/Components/Scorecard/Scorecard.styles.js
+++ b/packages/vis-core/src/Components/Scorecard/Scorecard.styles.js
@@ -113,3 +113,72 @@ export const EmptyState = styled.p`
   border: 1px solid #94a3b8;
   border-radius: 999px;
 `;
+
+/**
+ * Wrapper for a focusSummary field block (totals + collapsible breakdowns).
+ */
+export const FocusSummaryBlock = styled.div`
+  margin: 6px 0;
+  padding-left: 6px;
+  border-left: 2px solid #cbd5e1;
+`;
+
+/**
+ * Sub-heading for a focusSummary field, sits above its total rows.
+ */
+export const FocusSummaryLabel = styled.h5`
+  margin: 0 0 4px;
+  font-size: 0.85rem;
+  font-weight: 700;
+`;
+
+/**
+ * Expand/collapse trigger for a breakdown (area items or splitBy).
+ */
+export const ToggleBtn = styled.button`
+  border: none;
+  background: none;
+  color: #4c1d95;
+  padding: 4px 0;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-family: ${(p) => p.theme.standardFontFamily};
+  text-align: left;
+  text-decoration: underline;
+  &:hover {
+    color: #37136e;
+  }
+  &:focus-visible {
+    outline: 2px solid rgba(76, 29, 149, 0.9);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+`;
+
+/**
+ * Indented container for an expanded breakdown's rows.
+ */
+export const BreakdownList = styled.div`
+  padding-left: 10px;
+  margin-bottom: 4px;
+`;
+
+/**
+ * Groups a single splitBy dimension (e.g. "Household Type") and its labels.
+ */
+export const SplitDimension = styled.div`
+  margin-bottom: 6px;
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+/**
+ * Sub-heading naming a splitBy dimension within an expanded splitBy breakdown.
+ */
+export const SplitDimensionTitle = styled.p`
+  margin: 4px 0 2px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #64748b;
+`;

--- a/packages/vis-core/src/services/api/EndpointDefinitionClient.js
+++ b/packages/vis-core/src/services/api/EndpointDefinitionClient.js
@@ -373,52 +373,80 @@ export class EndpointDefinitionClient {
    * fetchDetails()
    *
    * High-level helper for "details" endpoints:
-   * - For GET endpoints: identifier fields are sent as query parameters
-   * - For POST endpoints: identifier fields are merged into the POST body
+   * - For GET endpoints: identifier fields (and any serverFilter query params) are sent as query parameters
+   * - For POST endpoints: identifier fields (and any serverFilter body params) are merged into the POST body
+   * - Supports a single id (idValue) or a bulk id list (idValues) under idParamName
    *
    * @param {import("./EndpointDefinitionClient").EndpointDefinition} endpoint
    * @param {{
    *   idParamName?: string,
    *   idValue?: string|number,
+   *   idValues?: Array<string|number>,
    *   extraQuery?: Record<string, any>
    * }} idConfig
+   * @param {Array<any>} [filters] - metadata-driven filters; expected to include { id, paramName }
+   * @param {Record<string, any>} [filterState] - keyed by filter.id
    * @returns {Promise<any|null>} Raw response or null on error
    *
    * @example
    * // GET details: /api/runs/details?run_id=123
    * const details = await endpointClient.fetchDetails(
    *   { path: "/api/runs/details", requestMethod: "GET" },
-   *   { idParamName: "run_id", idValue: 123 }
+   *   { idParamName: "run_id", idValue: 123 },
+   *   filters,
+   *   filterState
    * );
    *
    * @example
    * // POST details: body merged
    * const details = await endpointClient.fetchDetails(
    *   { path: "/api/runs/details", requestMethod: "POST", body: { verbose: true } },
-   *   { idParamName: "run_id", idValue: 123 }
+   *   { idParamName: "run_id", idValue: 123 },
+   *   filters,
+   *   filterState
    * );
+   * 
+   * @example
+   * // Bulk POST details with serverFilter params merged into the body
+   * const details = await endpointClient.fetchDetails(
+   *   { path: "/api/bronte/scorecard", requestMethod: "POST", serverFilter: { enabled: true, mode: "body", paramMap: { year: "year" } } },
+   *   { idParamName: "runCodes", idValues: ["HN", "HM"] },
+   *   filters,
+   *   filterState
+   * );
+   * // POST body: { runCodes: ["HN", "HM"], year: 2042 }
    */
-  async fetchDetails(endpoint, idConfig) {
+  async fetchDetails(endpoint, idConfig, filters, filterState) {
     const method = (endpoint?.requestMethod || "GET").toUpperCase();
 
+    const isBulk = Array.isArray(idConfig?.idValues);
+
     const idParams = {
-      ...(idConfig?.idParamName && idConfig?.idValue != null
+      ...(isBulk && idConfig?.idParamName && idConfig?.idValues != null
+        ? { [idConfig.idParamName]: idConfig.idValues }
+        : idConfig?.idParamName && idConfig?.idValue != null
         ? { [idConfig.idParamName]: idConfig.idValue }
         : {}),
       ...(idConfig?.extraQuery || {}),
     };
 
+    const { queryParams: sfQuery, body: sfBody } = buildServerRequestFromFilters(
+      endpoint?.serverFilter,
+      filters,
+      filterState
+    );
+
     try {
       if (method === "POST") {
         const res = await this.execute(endpoint, {
-          body: idParams,
-          queryParams: {},
+          body: { ...idParams, ...(sfBody || {}) },
+          queryParams: { ...(sfQuery || {}) },
         });
         return this.baseService.unwrapObjectResponse(res);
       }
 
       const res = await this.execute(endpoint, {
-        queryParams: idParams,
+        queryParams: { ...idParams, ...(sfQuery || {}) },
       });
       return this.baseService.unwrapObjectResponse(res);
     } catch (err) {


### PR DESCRIPTION
## Summary
Adds two additive capabilities to vis-core needed for the BRONTE Scorecard page (Epic 6). No existing behavior changes for current consumers (Economic Summaries verified).

## Changes
**DirectoryScorecardsPage.jsx** 
- Added `detailsFetchMode: "bulk"` support: when set on `recordDetailsEndpoint`, all selected ids are sent in a single `fetchDetails` call (via `idsRequestKey`) instead of one request per selected record. 
- Added `disableTopFilterScoping` option on `recordsEndpoint`, letting a page opt out of client-side top-filter scoping on the records list (needed where top filters apply only to the details request, not the driving table). 
- Details are now refetched, and stale cache entries invalidated, when filter values relevant to `recordDetailsEndpoint.serverFilter` change (previously details only refetched on selection change, never on filter change).

**EndpointDefinitionClient.js**
- `fetchDetails()` now accepts an optional `idValues` array (alongside the existing single `idValue`) for bulk requests, and optional `filters`/`filterState` params to merge `serverFilter`-derived query/body params into details requests (previously only `fetchList()` supported this).
- New params default to `undefined`; existing two-argument callers behave identically to before.

**Scorecard.jsx / Scorecard.styles.jsx**
- New `focusSummary` field type (opt-in via `field.type`), rendering a totals block (Focus Area / Rest of North / Rest of GB) with independently collapsible `focusItems` (area) and `splitBy` (dimension) breakdowns.
- Fields without `type` set continue through the original rendering path, unchanged.

## Backward compatibility
- Verified Economic Summaries page renders and functions identically pre/post change.
- No existing method signatures had required params changed or removed.

## Testing
- Manual testing against BRONTE Scorecard page (bulk fetch, serverFilter body params, focusSummary rendering with real API data).

## Notes 
- `fetchDetails()`'s bulk branch guards on both `idParamName` and `idValues` being present before building the request key, mirroring the existing single-id branch's guard pattern.

Closes https://github.com/Transport-for-the-North/BRONTE-Visualisation-Framework/issues/138