### PR TITLE
Fix metadata table cache never invalidating in useMetadataDrivenFilters

### DIFF
--- a/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
+++ b/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
@@ -3,6 +3,7 @@ import { PageContext, FilterContext } from "contexts";
 import { api } from "services";
 import { updateFilterValidity, correctInitialCrossFilterValues, correctRuntimeCrossFilterValues } from "utils";
 import { applyWhereConditions, sortValues, buildDeterministicFilterId } from "utils";
+import { fetchWithCache } from "utils/metadataCache";
 
 /**
  * callMetadataEndpoint
@@ -24,107 +25,15 @@ async function callMetadataEndpoint(endpoint) {
   return api.baseService.get(endpoint.path, opts);
 }
 
-const METADATA_CACHE_KEY_PREFIX = "metadata_cache_";
-const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const metadataPromiseCache = new Map();
-
-// Clear all sessionStorage metadata entries on module initialisation.
-// This runs on every full page reload,
-// ensuring users always get fresh data after a refresh without needing to
-// open the console. The in-memory Map is naturally empty at this point since
-// the module is being freshly evaluated.
-try {
-  const keysToRemove = [];
-  for (let i = 0; i < sessionStorage.length; i++) {
-    const key = sessionStorage.key(i);
-    if (key && key.startsWith(METADATA_CACHE_KEY_PREFIX)) {
-      keysToRemove.push(key);
-    }
-  }
-  keysToRemove.forEach((key) => sessionStorage.removeItem(key));
-} catch (e) {
-  // sessionStorage may be unavailable in some environments (e.g. SSR, sandboxed iframes)
-}
-
 /**
- * Executes a GET or POST request for a metadata table and caches the resulting Promise.
- * This prevents duplicate concurrent network requests for the same metadata table and
- * caches the result across SPA page transitions that share the same metadata requirements.
- * Data is also persisted to sessionStorage with a TTL so that cache entries expire
- * automatically and don't serve stale data indefinitely.
+ * Fetch a metadata table through the shared TTL cache.
+ * Delegates to callMetadataEndpoint for the actual network request.
  *
- * Cache invalidation strategy:
- * - **In-memory Map**: Entries are stored with a timestamp and checked against CACHE_TTL_MS.
- *   Expired entries are evicted on the next access.
- * - **sessionStorage**: Entries store { data, timestamp } and are TTL-checked on read.
- *   All entries are also cleared on module initialisation (i.e. any full page reload).
- * - **On error**: Both in-memory and sessionStorage entries are removed so the next
- *   call always retries the network.
- *
- * @param {Object} endpoint - The endpoint configuration object.
- * @param {string} endpoint.path - The API path for the metadata table.
- * @param {'GET'|'POST'} [endpoint.requestMethod='GET'] - The HTTP method to use.
- * @param {Object} [endpoint.requestOptions] - Additional fetch options.
- * @param {Object} [endpoint.body] - The request body for POST requests.
- * @returns {Promise<any>} A Promise that resolves to the parsed response payload.
- * @throws {Error} Propagates API errors and automatically invalidates the failed cache entry.
+ * @param {Object} endpoint - Endpoint configuration object.
+ * @returns {Promise<any>} Parsed response payload (possibly cached).
  */
 async function callMetadataEndpointWithCache(endpoint) {
-  const cacheKey = JSON.stringify({
-    path: endpoint.path,
-    method: (endpoint.requestMethod || "GET").toUpperCase(),
-    body: endpoint.body || {}
-  });
-
-  // 1. Check in-memory promise cache with TTL (prevents duplicate simultaneous requests)
-  const cached = metadataPromiseCache.get(cacheKey);
-  if (cached && (Date.now() - cached.timestamp < CACHE_TTL_MS)) {
-    return cached.promise;
-  }
-  // Expired: remove stale entry so it doesn't block a fresh fetch
-  if (cached) {
-    metadataPromiseCache.delete(cacheKey);
-  }
-
-  // 2. Check sessionStorage with TTL
-  const storageKey = METADATA_CACHE_KEY_PREFIX + cacheKey;
-  const storedRaw = sessionStorage.getItem(storageKey);
-  if (storedRaw) {
-    try {
-      const stored = JSON.parse(storedRaw);
-      if (stored.timestamp && (Date.now() - stored.timestamp < CACHE_TTL_MS)) {
-        // Populate in-memory cache to avoid repeated JSON.parse on subsequent calls
-        const resolvedPromise = Promise.resolve(stored.data);
-        metadataPromiseCache.set(cacheKey, { promise: resolvedPromise, timestamp: stored.timestamp });
-        return resolvedPromise;
-      }
-      // Expired: remove stale entry
-      sessionStorage.removeItem(storageKey);
-    } catch (e) {
-      console.warn("Failed to parse cached metadata from sessionStorage, removing entry", e);
-      sessionStorage.removeItem(storageKey);
-    }
-  }
-
-  // 3. Fetch from network and cache with timestamp
-  const now = Date.now();
-  const promise = callMetadataEndpoint(endpoint)
-    .then((data) => {
-      try {
-        sessionStorage.setItem(storageKey, JSON.stringify({ data, timestamp: now }));
-      } catch (e) {
-        console.warn("Failed to persist metadata to sessionStorage. Quota exceeded?", e);
-      }
-      return data;
-    })
-    .catch((err) => {
-      metadataPromiseCache.delete(cacheKey);
-      sessionStorage.removeItem(storageKey);
-      throw err;
-    });
-
-  metadataPromiseCache.set(cacheKey, { promise, timestamp: now });
-  return promise;
+  return fetchWithCache(endpoint, callMetadataEndpoint);
 }
 
 /**

--- a/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
+++ b/packages/vis-core/src/hooks/useMetadataDrivenFilters.jsx
@@ -25,13 +25,41 @@ async function callMetadataEndpoint(endpoint) {
 }
 
 const METADATA_CACHE_KEY_PREFIX = "metadata_cache_";
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const metadataPromiseCache = new Map();
+
+// Clear all sessionStorage metadata entries on module initialisation.
+// This runs on every full page reload,
+// ensuring users always get fresh data after a refresh without needing to
+// open the console. The in-memory Map is naturally empty at this point since
+// the module is being freshly evaluated.
+try {
+  const keysToRemove = [];
+  for (let i = 0; i < sessionStorage.length; i++) {
+    const key = sessionStorage.key(i);
+    if (key && key.startsWith(METADATA_CACHE_KEY_PREFIX)) {
+      keysToRemove.push(key);
+    }
+  }
+  keysToRemove.forEach((key) => sessionStorage.removeItem(key));
+} catch (e) {
+  // sessionStorage may be unavailable in some environments (e.g. SSR, sandboxed iframes)
+}
 
 /**
  * Executes a GET or POST request for a metadata table and caches the resulting Promise.
- * This prevents duplicate concurrent network requests for the same metadata table and 
- * caches the result across page transitions that share the same metadata requirements.
- * Data is also persisted to sessionStorage to survive hard page reloads during a session.
+ * This prevents duplicate concurrent network requests for the same metadata table and
+ * caches the result across SPA page transitions that share the same metadata requirements.
+ * Data is also persisted to sessionStorage with a TTL so that cache entries expire
+ * automatically and don't serve stale data indefinitely.
+ *
+ * Cache invalidation strategy:
+ * - **In-memory Map**: Entries are stored with a timestamp and checked against CACHE_TTL_MS.
+ *   Expired entries are evicted on the next access.
+ * - **sessionStorage**: Entries store { data, timestamp } and are TTL-checked on read.
+ *   All entries are also cleared on module initialisation (i.e. any full page reload).
+ * - **On error**: Both in-memory and sessionStorage entries are removed so the next
+ *   call always retries the network.
  *
  * @param {Object} endpoint - The endpoint configuration object.
  * @param {string} endpoint.path - The API path for the metadata table.
@@ -48,27 +76,42 @@ async function callMetadataEndpointWithCache(endpoint) {
     body: endpoint.body || {}
   });
 
-  // 1. Check in-memory promise cache (prevents duplicate simultaneous requests)
-  if (metadataPromiseCache.has(cacheKey)) {
-    return metadataPromiseCache.get(cacheKey);
+  // 1. Check in-memory promise cache with TTL (prevents duplicate simultaneous requests)
+  const cached = metadataPromiseCache.get(cacheKey);
+  if (cached && (Date.now() - cached.timestamp < CACHE_TTL_MS)) {
+    return cached.promise;
+  }
+  // Expired: remove stale entry so it doesn't block a fresh fetch
+  if (cached) {
+    metadataPromiseCache.delete(cacheKey);
   }
 
-  // 2. Check sessionStorage for persisted data from previous visits
+  // 2. Check sessionStorage with TTL
   const storageKey = METADATA_CACHE_KEY_PREFIX + cacheKey;
-  const storedData = sessionStorage.getItem(storageKey);
-  if (storedData) {
+  const storedRaw = sessionStorage.getItem(storageKey);
+  if (storedRaw) {
     try {
-      return JSON.parse(storedData);
+      const stored = JSON.parse(storedRaw);
+      if (stored.timestamp && (Date.now() - stored.timestamp < CACHE_TTL_MS)) {
+        // Populate in-memory cache to avoid repeated JSON.parse on subsequent calls
+        const resolvedPromise = Promise.resolve(stored.data);
+        metadataPromiseCache.set(cacheKey, { promise: resolvedPromise, timestamp: stored.timestamp });
+        return resolvedPromise;
+      }
+      // Expired: remove stale entry
+      sessionStorage.removeItem(storageKey);
     } catch (e) {
-      console.warn("Failed to parse cached metadata from sessionStorage", e);
+      console.warn("Failed to parse cached metadata from sessionStorage, removing entry", e);
+      sessionStorage.removeItem(storageKey);
     }
   }
 
-  // 3. Fetch from network and cache
+  // 3. Fetch from network and cache with timestamp
+  const now = Date.now();
   const promise = callMetadataEndpoint(endpoint)
     .then((data) => {
       try {
-        sessionStorage.setItem(storageKey, JSON.stringify(data));
+        sessionStorage.setItem(storageKey, JSON.stringify({ data, timestamp: now }));
       } catch (e) {
         console.warn("Failed to persist metadata to sessionStorage. Quota exceeded?", e);
       }
@@ -76,10 +119,11 @@ async function callMetadataEndpointWithCache(endpoint) {
     })
     .catch((err) => {
       metadataPromiseCache.delete(cacheKey);
+      sessionStorage.removeItem(storageKey);
       throw err;
     });
 
-  metadataPromiseCache.set(cacheKey, promise);
+  metadataPromiseCache.set(cacheKey, { promise, timestamp: now });
   return promise;
 }
 

--- a/packages/vis-core/src/utils/metadataCache.js
+++ b/packages/vis-core/src/utils/metadataCache.js
@@ -1,0 +1,139 @@
+/**
+ * metadataCache
+ *
+ * A two-layer caching utility for metadata table API responses:
+ * 1. In-memory Map (fast, deduplicates concurrent requests within the SPA)
+ * 2. sessionStorage (persists across SPA page transitions)
+ *
+ * Both layers are TTL-bounded. All sessionStorage entries are cleared on module
+ * initialisation (i.e. any full page reload) so users can recover from stale
+ * data with a simple refresh.
+ */
+
+const METADATA_CACHE_KEY_PREFIX = "metadata_cache_";
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** @type {Map<string, { promise: Promise<any>, timestamp: number }>} */
+const metadataPromiseCache = new Map();
+
+// Clear all sessionStorage metadata entries on module initialisation.
+// This runs on every full page reload (F5, Ctrl+Shift+R, or fresh navigation),
+// ensuring users always get fresh data after a refresh without needing to
+// open the console. The in-memory Map is naturally empty at this point since
+// the module is being freshly evaluated.
+try {
+  const keysToRemove = [];
+  for (let i = 0; i < sessionStorage.length; i++) {
+    const key = sessionStorage.key(i);
+    if (key && key.startsWith(METADATA_CACHE_KEY_PREFIX)) {
+      keysToRemove.push(key);
+    }
+  }
+  keysToRemove.forEach((key) => sessionStorage.removeItem(key));
+} catch (e) {
+  // sessionStorage may be unavailable in some environments (e.g. SSR, sandboxed iframes)
+}
+
+/**
+ * Build a deterministic cache key from an endpoint configuration.
+ *
+ * @param {Object} endpoint
+ * @returns {string}
+ */
+function buildCacheKey(endpoint) {
+  return JSON.stringify({
+    path: endpoint.path,
+    method: (endpoint.requestMethod || "GET").toUpperCase(),
+    body: endpoint.body || {},
+  });
+}
+
+/**
+ * Fetch data through the two-layer cache (in-memory → sessionStorage → network).
+ *
+ * @param {Object} endpoint - Endpoint configuration.
+ * @param {Function} fetchFn - The actual network fetch function: (endpoint) => Promise<data>.
+ * @param {number} [ttlMs] - TTL in milliseconds. Defaults to DEFAULT_CACHE_TTL_MS.
+ * @returns {Promise<any>}
+ */
+async function fetchWithCache(endpoint, fetchFn, ttlMs = DEFAULT_CACHE_TTL_MS) {
+  const cacheKey = buildCacheKey(endpoint);
+  const now = Date.now();
+
+  // 1. Check in-memory promise cache with TTL (prevents duplicate simultaneous requests)
+  const cached = metadataPromiseCache.get(cacheKey);
+  if (cached && (now - cached.timestamp < ttlMs)) {
+    return cached.promise;
+  }
+  // Expired — remove stale entry so it doesn't block a fresh fetch
+  if (cached) {
+    metadataPromiseCache.delete(cacheKey);
+  }
+
+  // 2. Check sessionStorage with TTL
+  const storageKey = METADATA_CACHE_KEY_PREFIX + cacheKey;
+  const storedRaw = sessionStorage.getItem(storageKey);
+  if (storedRaw) {
+    try {
+      const stored = JSON.parse(storedRaw);
+      if (stored.timestamp && (now - stored.timestamp < ttlMs)) {
+        // Populate in-memory cache to avoid repeated JSON.parse on subsequent calls
+        const resolvedPromise = Promise.resolve(stored.data);
+        metadataPromiseCache.set(cacheKey, { promise: resolvedPromise, timestamp: stored.timestamp });
+        return resolvedPromise;
+      }
+      // Expired — remove stale entry
+      sessionStorage.removeItem(storageKey);
+    } catch (e) {
+      console.warn("Failed to parse cached metadata from sessionStorage, removing entry", e);
+      sessionStorage.removeItem(storageKey);
+    }
+  }
+
+  // 3. Fetch from network and cache with timestamp
+  const promise = fetchFn(endpoint)
+    .then((data) => {
+      try {
+        sessionStorage.setItem(storageKey, JSON.stringify({ data, timestamp: now }));
+      } catch (e) {
+        console.warn("Failed to persist metadata to sessionStorage. Quota exceeded?", e);
+      }
+      return data;
+    })
+    .catch((err) => {
+      metadataPromiseCache.delete(cacheKey);
+      sessionStorage.removeItem(storageKey);
+      throw err;
+    });
+
+  metadataPromiseCache.set(cacheKey, { promise, timestamp: now });
+  return promise;
+}
+
+/**
+ * Clear both cache layers. Useful for testing or manual invalidation.
+ */
+function clearMetadataCache() {
+  metadataPromiseCache.clear();
+  try {
+    const keysToRemove = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const key = sessionStorage.key(i);
+      if (key && key.startsWith(METADATA_CACHE_KEY_PREFIX)) {
+        keysToRemove.push(key);
+      }
+    }
+    keysToRemove.forEach((key) => sessionStorage.removeItem(key));
+  } catch (e) {
+    // sessionStorage may be unavailable
+  }
+}
+
+export {
+  METADATA_CACHE_KEY_PREFIX,
+  DEFAULT_CACHE_TTL_MS,
+  metadataPromiseCache,
+  buildCacheKey,
+  fetchWithCache,
+  clearMetadataCache,
+};

--- a/packages/vis-core/src/utils/metadataCache.test.js
+++ b/packages/vis-core/src/utils/metadataCache.test.js
@@ -1,0 +1,264 @@
+import {
+  METADATA_CACHE_KEY_PREFIX,
+  DEFAULT_CACHE_TTL_MS,
+  metadataPromiseCache,
+  buildCacheKey,
+  fetchWithCache,
+  clearMetadataCache,
+} from "./metadataCache";
+
+const ENDPOINT = { path: "/api/metadata/scenarios", requestMethod: "GET" };
+const ENDPOINT_POST = { path: "/api/metadata/modes", requestMethod: "POST", body: { region: "north" } };
+const MOCK_DATA = [{ id: 1, name: "Scenario A" }, { id: 2, name: "Scenario B" }];
+
+beforeEach(() => {
+  clearMetadataCache();
+  sessionStorage.clear();
+});
+
+// ─── buildCacheKey ───────────────────────────────────────────────
+
+describe("buildCacheKey", () => {
+  it("produces a deterministic key from endpoint config", () => {
+    const key = buildCacheKey(ENDPOINT);
+    expect(typeof key).toBe("string");
+    expect(key).toBe(buildCacheKey({ ...ENDPOINT }));
+  });
+
+  it("defaults method to GET when omitted", () => {
+    const withoutMethod = buildCacheKey({ path: "/api/test" });
+    const withGet = buildCacheKey({ path: "/api/test", requestMethod: "GET" });
+    expect(withoutMethod).toBe(withGet);
+  });
+
+  it("produces different keys for different endpoints", () => {
+    expect(buildCacheKey(ENDPOINT)).not.toBe(buildCacheKey(ENDPOINT_POST));
+  });
+
+  it("produces different keys when body differs", () => {
+    const a = buildCacheKey({ path: "/api/test", requestMethod: "POST", body: { x: 1 } });
+    const b = buildCacheKey({ path: "/api/test", requestMethod: "POST", body: { x: 2 } });
+    expect(a).not.toBe(b);
+  });
+});
+
+// ─── fetchWithCache — basic behaviour ────────────────────────────
+
+describe("fetchWithCache", () => {
+  it("calls the fetch function and returns the data", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(MOCK_DATA);
+    const result = await fetchWithCache(ENDPOINT, fetchFn);
+    expect(result).toEqual(MOCK_DATA);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith(ENDPOINT);
+  });
+
+  it("returns cached data on the second call without re-fetching", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(MOCK_DATA);
+    await fetchWithCache(ENDPOINT, fetchFn);
+    const result = await fetchWithCache(ENDPOINT, fetchFn);
+    expect(result).toEqual(MOCK_DATA);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches independently per endpoint", async () => {
+    const fetchA = jest.fn().mockResolvedValue([1]);
+    const fetchB = jest.fn().mockResolvedValue([2]);
+    const a = await fetchWithCache(ENDPOINT, fetchA);
+    const b = await fetchWithCache(ENDPOINT_POST, fetchB);
+    expect(a).toEqual([1]);
+    expect(b).toEqual([2]);
+    expect(fetchA).toHaveBeenCalledTimes(1);
+    expect(fetchB).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates concurrent requests for the same endpoint", async () => {
+    let resolvePromise;
+    const fetchFn = jest.fn().mockImplementation(
+      () => new Promise((resolve) => { resolvePromise = resolve; })
+    );
+
+    const p1 = fetchWithCache(ENDPOINT, fetchFn);
+    const p2 = fetchWithCache(ENDPOINT, fetchFn);
+
+    resolvePromise(MOCK_DATA);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual(MOCK_DATA);
+    expect(r2).toEqual(MOCK_DATA);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── fetchWithCache — TTL expiry ─────────────────────────────────
+
+describe("fetchWithCache — TTL expiry", () => {
+  it("re-fetches after the TTL expires (in-memory)", async () => {
+    const fetchFn = jest.fn()
+      .mockResolvedValueOnce([1])
+      .mockResolvedValueOnce([2]);
+
+    await fetchWithCache(ENDPOINT, fetchFn, 100);
+
+    // Advance past TTL
+    jest.spyOn(Date, "now").mockReturnValue(Date.now() + 200);
+
+    const result = await fetchWithCache(ENDPOINT, fetchFn, 100);
+    expect(result).toEqual([2]);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    Date.now.mockRestore();
+  });
+
+  it("serves from cache when within TTL", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(MOCK_DATA);
+    const now = Date.now();
+    jest.spyOn(Date, "now").mockReturnValue(now);
+
+    await fetchWithCache(ENDPOINT, fetchFn, 10000);
+
+    // Advance but stay within TTL
+    Date.now.mockReturnValue(now + 5000);
+    const result = await fetchWithCache(ENDPOINT, fetchFn, 10000);
+    expect(result).toEqual(MOCK_DATA);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    Date.now.mockRestore();
+  });
+});
+
+// ─── fetchWithCache — sessionStorage layer ───────────────────────
+
+describe("fetchWithCache — sessionStorage", () => {
+  it("persists data to sessionStorage on successful fetch", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(MOCK_DATA);
+    await fetchWithCache(ENDPOINT, fetchFn);
+
+    const storageKey = METADATA_CACHE_KEY_PREFIX + buildCacheKey(ENDPOINT);
+    const stored = JSON.parse(sessionStorage.getItem(storageKey));
+    expect(stored.data).toEqual(MOCK_DATA);
+    expect(typeof stored.timestamp).toBe("number");
+  });
+
+  it("serves from sessionStorage when in-memory cache is empty but sessionStorage is valid", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(MOCK_DATA);
+
+    // Populate both caches
+    await fetchWithCache(ENDPOINT, fetchFn);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Clear only the in-memory cache (simulates module re-eval scenario
+    // where sessionStorage was pre-populated from a prior call within TTL)
+    metadataPromiseCache.clear();
+
+    // Manually re-set sessionStorage with a fresh timestamp so TTL passes
+    const storageKey = METADATA_CACHE_KEY_PREFIX + buildCacheKey(ENDPOINT);
+    sessionStorage.setItem(storageKey, JSON.stringify({ data: MOCK_DATA, timestamp: Date.now() }));
+
+    const result = await fetchWithCache(ENDPOINT, fetchFn);
+    expect(result).toEqual(MOCK_DATA);
+    // Should NOT have re-fetched — sessionStorage served the data
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores expired sessionStorage entries and re-fetches", async () => {
+    const storageKey = METADATA_CACHE_KEY_PREFIX + buildCacheKey(ENDPOINT);
+    // Pre-seed sessionStorage with an expired entry
+    sessionStorage.setItem(storageKey, JSON.stringify({
+      data: [{ stale: true }],
+      timestamp: Date.now() - DEFAULT_CACHE_TTL_MS - 1000,
+    }));
+
+    const fetchFn = jest.fn().mockResolvedValue(MOCK_DATA);
+    const result = await fetchWithCache(ENDPOINT, fetchFn);
+    expect(result).toEqual(MOCK_DATA);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Expired entry should have been replaced
+    const stored = JSON.parse(sessionStorage.getItem(storageKey));
+    expect(stored.data).toEqual(MOCK_DATA);
+  });
+
+  it("removes corrupt sessionStorage entries and re-fetches", async () => {
+    const storageKey = METADATA_CACHE_KEY_PREFIX + buildCacheKey(ENDPOINT);
+    sessionStorage.setItem(storageKey, "not-valid-json{{{");
+
+    const fetchFn = jest.fn().mockResolvedValue(MOCK_DATA);
+    const result = await fetchWithCache(ENDPOINT, fetchFn);
+    expect(result).toEqual(MOCK_DATA);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── fetchWithCache — error handling ─────────────────────────────
+
+describe("fetchWithCache — error handling", () => {
+  it("clears both cache layers on fetch error", async () => {
+    const error = new Error("Network failure");
+    const fetchFn = jest.fn().mockRejectedValue(error);
+
+    await expect(fetchWithCache(ENDPOINT, fetchFn)).rejects.toThrow("Network failure");
+
+    // In-memory cache should be empty
+    const cacheKey = buildCacheKey(ENDPOINT);
+    expect(metadataPromiseCache.has(cacheKey)).toBe(false);
+
+    // sessionStorage should be empty
+    const storageKey = METADATA_CACHE_KEY_PREFIX + cacheKey;
+    expect(sessionStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it("allows retry after a failed fetch", async () => {
+    const error = new Error("Temporary failure");
+    const fetchFn = jest.fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(MOCK_DATA);
+
+    await expect(fetchWithCache(ENDPOINT, fetchFn)).rejects.toThrow("Temporary failure");
+
+    // Second call should succeed
+    const result = await fetchWithCache(ENDPOINT, fetchFn);
+    expect(result).toEqual(MOCK_DATA);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── clearMetadataCache ──────────────────────────────────────────
+
+describe("clearMetadataCache", () => {
+  it("clears the in-memory cache", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(MOCK_DATA);
+    await fetchWithCache(ENDPOINT, fetchFn);
+    expect(metadataPromiseCache.size).toBeGreaterThan(0);
+
+    clearMetadataCache();
+    expect(metadataPromiseCache.size).toBe(0);
+  });
+
+  it("clears metadata entries from sessionStorage without affecting other keys", async () => {
+    const fetchFn = jest.fn().mockResolvedValue(MOCK_DATA);
+    await fetchWithCache(ENDPOINT, fetchFn);
+
+    // Add a non-metadata key
+    sessionStorage.setItem("unrelated_key", "keep me");
+
+    clearMetadataCache();
+
+    const storageKey = METADATA_CACHE_KEY_PREFIX + buildCacheKey(ENDPOINT);
+    expect(sessionStorage.getItem(storageKey)).toBeNull();
+    expect(sessionStorage.getItem("unrelated_key")).toBe("keep me");
+  });
+
+  it("forces a re-fetch on the next call", async () => {
+    const fetchFn = jest.fn()
+      .mockResolvedValueOnce([1])
+      .mockResolvedValueOnce([2]);
+
+    await fetchWithCache(ENDPOINT, fetchFn);
+    clearMetadataCache();
+
+    const result = await fetchWithCache(ENDPOINT, fetchFn);
+    expect(result).toEqual([2]);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Description

The metadata table cache in `useMetadataDrivenFilters` had no invalidation mechanism: both the in-memory `Map` and `sessionStorage` layer were write-once for the lifetime of a session. This caused stale filter values to persist across page transitions, and even a hard refresh couldn't clear them since `sessionStorage` survives reloads.

## Changes

- Added a 5-minute TTL to both the in-memory promise cache and `sessionStorage` entries. Cache entries now store `{ data, timestamp }` and are evicted on access once expired.
- Added a module-initialisation block that clears all `metadata_cache_*` keys from `sessionStorage` when the module is first evaluated. This ensures any full page reload starts with a clean cache.
- Added `sessionStorage.removeItem()` to the `.catch` error handler so a failed fetch no longer leaves a ghost entry that blocks future retries.
- Factored the metadata caching mechanism into a separate utils module, to enable testing
- Added unit tests to the metadata caching mechanism

## Why

The original cache was designed to deduplicate concurrent requests and avoid redundant fetches during SPA navigation, but it had no expiry. Once a metadata table was fetched successfully, the cached response was returned for every subsequent call, even if the API data had changed server-side. The `sessionStorage` layer compounded this by surviving page refreshes, meaning the only way to get fresh data was to close the browser tab entirely.

The TTL approach preserves the deduplication and cross-page caching benefits while bounding staleness to 5 minutes. The module-init clear provides a reliable manual escape hatch via refresh.

## Tests

- `MapContext.test.jsx`: 2/2 passing. No regressions from the cache changes.
- Additional `metadataCache.test.js` for the caching functions
- Pre-existing `act()` warnings are unrelated (async state updates in the test harness).
