### PR TITLE
Fix dynamic legend bin truncation and incorrect capping message

### DIFF
--- a/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.utils.js
+++ b/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.utils.js
@@ -453,9 +453,14 @@ export const getOutOfBandFlags = (data, numericEntries) => {
   const bandMax = bandEdges.reduce(maxReducer, -Infinity);
   const values = extractDataValues(data);
   if (values.length === 0) return { belowMin: false, aboveMax: false };
+  
+  // Apply a small tolerance to account for 2-decimal rounding in the 
+  // classification pipeline and floating point fuzziness.
+  const TOLERANCE = 0.005001;
+  
   return {
-    belowMin: values.reduce(minReducer, Infinity) < bandMin,
-    aboveMax: values.reduce(maxReducer, -Infinity) > bandMax,
+    belowMin: values.reduce(minReducer, Infinity) < bandMin - TOLERANCE,
+    aboveMax: values.reduce(maxReducer, -Infinity) > bandMax + TOLERANCE,
   };
 };
 

--- a/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.utils.test.js
+++ b/packages/vis-core/src/Components/DynamicLegend/DynamicLegend.utils.test.js
@@ -14,4 +14,25 @@ describe('getOutOfBandFlags', () => {
       expect(result.aboveMax).toBe(true);
     }).not.toThrow();
   });
+  it('does not flag as out of band for minor precision differences within tolerance', () => {
+    // The tolerance is 0.005001. A difference of 0.004 should NOT trigger the flag.
+    const data = [{ value: 2936.004 }, { value: 99.996 }];
+    // Band limits are [100, 2936]
+    const numericEntries = [100, 1500, 2936];
+
+    const result = getOutOfBandFlags(data, numericEntries);
+    expect(result.belowMin).toBe(false);
+    expect(result.aboveMax).toBe(false);
+  });
+
+  it('correctly flags as out of band for genuine differences outside tolerance', () => {
+    // The tolerance is 0.005001. A difference of 0.01 SHOULD trigger the flag.
+    const data = [{ value: 2936.01 }, { value: 99.99 }];
+    // Band limits are [100, 2936]
+    const numericEntries = [100, 1500, 2936];
+
+    const result = getOutOfBandFlags(data, numericEntries);
+    expect(result.belowMin).toBe(true);
+    expect(result.aboveMax).toBe(true);
+  });
 });

--- a/packages/vis-core/src/utils/map.js
+++ b/packages/vis-core/src/utils/map.js
@@ -1040,7 +1040,7 @@ export const reclassifyData = (
     }
     roundedBins = roundedBins.filter((value) => value !== 0);
     roundedBins = [...new Set(roundedBins)]; 
-    roundedBins = roundedBins.slice(0, 4);  
+    roundedBins = roundedBins.slice(-4);  
     if (style.includes("line")) return [0, ...roundedBins];
     const negativeBins = roundedBins.slice().reverse().map((val) => -val);
     return [...negativeBins, 0, ...roundedBins];


### PR DESCRIPTION
## Description
- Fixes the dynamic legend clipping the maximum bounds for diverging styles
- Suppresses false out-of-band warnings caused by precision inconsistencies

## Changes
- Updated `reclassifyData` in `map.js` to use `roundedBins.slice(-4)` rather than `.slice(0, 4)`
- Added a `TOLERANCE` value of `0.005001` to `getOutOfBandFlags` in `DynamicLegend.utils.js` when validating if data sits outside the legend bounds

## Why
- Taking the first four elements dropped the highest boundary limit, capping the legend's displayed range. By taking the final four elements instead, the absolute maximum boundary is preserved, while the lowest bound naturally anchors at `0`.
- The style generator naturally rounds limits to 2 decimal places to keep Mapbox expressions clean. However, the capping warning used strict evaluation against the unrounded raw data. The added tolerance ensures minor floating point fuzziness and 2-decimal rounding errors no longer trigger false "capped" warnings.

## Testing
- Added test cases to demonstrate the out-of-band warning only shows when required

Fixes #280 