### PR TITLE
Update tooltip to include units

### DIFF
--- a/packages/vis-core/src/utils/tooltip.js
+++ b/packages/vis-core/src/utils/tooltip.js
@@ -8,7 +8,7 @@
 export function buildDefaultTooltip({
   featureName,
   featureValueDisplay,
-  legendText,
+  unitText,
   valueText,
   metadataHtml = "",
 }) {
@@ -25,7 +25,7 @@ export function buildDefaultTooltip({
         <hr class="divider">
         <div class="metadata-item">
           <span class="metadata-key">${valueText}:</span>
-          <span class="metadata-value">${featureValueDisplay} ${legendText ?? ""}</span>
+          <span class="metadata-value">${featureValueDisplay} ${unitText ?? ""}</span>
         </div>
         ${metadataHtml}
       </div>`;
@@ -45,7 +45,7 @@ export function buildDefaultTooltip({
       <div class="popup-content">
         <div class="metadata-item">
           <span class="metadata-key">${valueText}:</span>
-          <span class="metadata-value">${featureValueDisplay} ${legendText ?? ""}</span>
+          <span class="metadata-value">${featureValueDisplay} ${unitText ?? ""}</span>
         </div>
         ${metadataHtml}
       </div>`;


### PR DESCRIPTION
Updated tooltip.js to use input unitText rather than previous legendText. 
legendText replaced with unitText in map.jsx and DualMaps.jsx but this not reflected in tooltip.

Tested locally, works okay.

