### PR TITLE
fix: restore mouse-wheel zoom on side-by-side maps

### DIFF
--- a/packages/vis-core/src/Components/MapLayout/DualMaps.jsx
+++ b/packages/vis-core/src/Components/MapLayout/DualMaps.jsx
@@ -917,9 +917,14 @@ const DualMaps = (props) => {
   useEffect(() => {
   if (!leftMap || !rightMap) return;
 
-  const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+  const isNarrowViewport = window.matchMedia('(max-width: 900px)').matches;
+  const hasCoarsePointer = window.matchMedia('(pointer: coarse)').matches ||
+    window.matchMedia('(any-pointer: coarse)').matches;
+  const hasFinePointer = window.matchMedia('(pointer: fine)').matches ||
+    window.matchMedia('(any-pointer: fine)').matches;
+  const isTouchOnlyMobile = isNarrowViewport && hasCoarsePointer && !hasFinePointer;
 
-  if (isTouch) {
+  if (isTouchOnlyMobile) {
     [leftMap, rightMap].forEach(m => {
       m.dragPan.enable();
       m.touchZoomRotate.enable();

--- a/packages/vis-core/src/hooks/useDualMaps.jsx
+++ b/packages/vis-core/src/hooks/useDualMaps.jsx
@@ -97,8 +97,14 @@ export const useDualMaps = (
       );
       rightMapInstance.resize();
 
-      const isMobile = window.matchMedia('(max-width: 900px)').matches;
-      if (isMobile) {
+      const isNarrowViewport = window.matchMedia('(max-width: 900px)').matches;
+      const hasCoarsePointer = window.matchMedia('(pointer: coarse)').matches ||
+        window.matchMedia('(any-pointer: coarse)').matches;
+      const hasFinePointer = window.matchMedia('(pointer: fine)').matches ||
+        window.matchMedia('(any-pointer: fine)').matches;
+      const shouldDisableDesktopInteractions = isNarrowViewport && hasCoarsePointer && !hasFinePointer;
+
+      if (shouldDisableDesktopInteractions) {
         [leftMapInstance, rightMapInstance].forEach(map => {
           map.scrollZoom.disable();      // prevent single-finger zoom
           map.dragPan.disable();         // prevent single-finger pan


### PR DESCRIPTION
1.prevent scroll-zoom from being disabled on mouse-enabled devices 
2.align dual-map interaction guards to apply touch restrictions only on touch-only mobile contexts 
3.update both map initialization and post-mount interaction effects for consistent behavior 
4.preserve intended mobile touch interaction constraints while enabling desktop/laptop wheel zoom

